### PR TITLE
Tidy up templates & package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "route-codegen",
   "version": "0.1.5",
   "description": "Route generator written in Typscript for React Router, NextJS, NodeJS and more",
+  "homepage": "https://github.com/eddeee888/route-codegen",
+  "bugs": "https://github.com/eddeee888/route-codegen/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eddeee888/route-codegen.git"
+  },
+  "license": "MIT",
   "main": "./dist/index.js",
   "bin": {
     "route-codegen": "./dist/bin/route-codegen.js"
@@ -15,13 +22,6 @@
     "build": "rm -rf ./dist && tsc",
     "format:prettier": "prettier --config .prettierrc --write \"src/**/*.{ts,tsx}\""
   },
-  "keywords": [
-    "react-router",
-    "next-js",
-    "route",
-    "generator"
-  ],
-  "license": "MIT",
   "devDependencies": {
     "@types/jest": "^25.1.4",
     "@types/js-yaml": "^3.12.2",
@@ -37,5 +37,11 @@
     "js-yaml": "^3.13.1",
     "path-to-regexp": "^6.1.0",
     "yargs": "^15.1.0"
-  }
+  },
+  "keywords": [
+    "react-router",
+    "next-js",
+    "route",
+    "generator"
+  ]
 }

--- a/sample/output/app/routes/about/LinkAbout.tsx
+++ b/sample/output/app/routes/about/LinkAbout.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternAbout } from './patternAbout';
+import { patternAbout, UrlPartsAbout } from './patternAbout';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsAbout;
 const LinkAbout: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAbout, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/about/generateUrlAbout.ts
+++ b/sample/output/app/routes/about/generateUrlAbout.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAbout, UrlPartsAbout } from './patternAbout';
-const generateUrlAbout = (urlParts: UrlPartsAbout) => generateUrl(patternAbout, {}, urlParts.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, {}, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/app/routes/account/LinkAccount.tsx
+++ b/sample/output/app/routes/account/LinkAccount.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
-import Link, { LinkProps } from 'react-router-dom';
-import { patternAccount } from './patternAccount';
-type LinkAccountProps = Omit<LinkProps, 'to'>;
+import { LinkProps, Link } from 'react-router-dom';
+import { patternAccount, UrlPartsAccount } from './patternAccount';
+type LinkAccountProps = Omit<LinkProps, 'to'> & UrlPartsAccount;
 const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAccount, {}, urlQuery);
   return <Link {...props} to={to} />;

--- a/sample/output/app/routes/account/generateUrlAccount.ts
+++ b/sample/output/app/routes/account/generateUrlAccount.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAccount, UrlPartsAccount } from './patternAccount';
-const generateUrlAccount = (urlParts: UrlPartsAccount) => generateUrl(patternAccount, {}, urlParts.urlQuery);
+const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/app/routes/home/LinkHome.tsx
+++ b/sample/output/app/routes/home/LinkHome.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternHome } from './patternHome';
+import { patternHome, UrlPartsHome } from './patternHome';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternHome, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/home/generateUrlHome.ts
+++ b/sample/output/app/routes/home/generateUrlHome.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternHome, UrlPartsHome } from './patternHome';
-const generateUrlHome = (urlParts: UrlPartsHome) => generateUrl(patternHome, {}, urlParts.urlQuery);
+const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/app/routes/legacy/LinkLegacy.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternLegacy } from './patternLegacy';
+import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsLegacy;
 const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLegacy, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/app/routes/legacy/generateUrlLegacy.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
-const generateUrlLegacy = (urlParts: UrlPartsLegacy) => generateUrl(patternLegacy, {}, urlParts.urlQuery);
+const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/app/routes/login/LinkLogin.tsx
+++ b/sample/output/app/routes/login/LinkLogin.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternLogin } from './patternLogin';
+import { patternLogin, UrlPartsLogin } from './patternLogin';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsLogin;
 const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLogin, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/login/generateUrlLogin.ts
+++ b/sample/output/app/routes/login/generateUrlLogin.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLogin, UrlPartsLogin } from './patternLogin';
-const generateUrlLogin = (urlParts: UrlPartsLogin) => generateUrl(patternLogin, {}, urlParts.urlQuery);
+const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/app/routes/signup/LinkSignup.tsx
+++ b/sample/output/app/routes/signup/LinkSignup.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternSignup } from './patternSignup';
+import { patternSignup, UrlPartsSignup } from './patternSignup';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsSignup;
 const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternSignup, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/signup/generateUrlSignup.ts
+++ b/sample/output/app/routes/signup/generateUrlSignup.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternSignup, UrlPartsSignup } from './patternSignup';
-const generateUrlSignup = (urlParts: UrlPartsSignup) => generateUrl(patternSignup, {}, urlParts.urlQuery);
+const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/app/routes/toc/LinkToc.tsx
+++ b/sample/output/app/routes/toc/LinkToc.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternToc } from './patternToc';
+import { patternToc, UrlPartsToc } from './patternToc';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsToc;
 const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternToc, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/app/routes/toc/generateUrlToc.ts
+++ b/sample/output/app/routes/toc/generateUrlToc.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternToc, UrlPartsToc } from './patternToc';
-const generateUrlToc = (urlParts: UrlPartsToc) => generateUrl(patternToc, {}, urlParts.urlQuery);
+const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/app/routes/user/LinkUser.tsx
+++ b/sample/output/app/routes/user/LinkUser.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
-import Link, { LinkProps } from 'react-router-dom';
-import { patternUser } from './patternUser';
-type LinkUserProps = Omit<LinkProps, 'to'>;
+import { LinkProps, Link } from 'react-router-dom';
+import { patternUser, UrlPartsUser } from './patternUser';
+type LinkUserProps = Omit<LinkProps, 'to'> & UrlPartsUser;
 const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
   const to = generateUrl(patternUser, path, urlQuery);
   return <Link {...props} to={to} />;

--- a/sample/output/app/routes/user/generateUrlUser.ts
+++ b/sample/output/app/routes/user/generateUrlUser.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternUser, UrlPartsUser } from './patternUser';
-const generateUrlUser = (urlParts: UrlPartsUser) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/auth/routes/about/LinkAbout.tsx
+++ b/sample/output/auth/routes/about/LinkAbout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternAbout } from './patternAbout';
-type LinkAboutProps = Omit<AnchorProps, 'href'>;
+import { patternAbout, UrlPartsAbout } from './patternAbout';
+type LinkAboutProps = Omit<AnchorProps, 'href'> & UrlPartsAbout;
 const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAbout, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/about/generateUrlAbout.ts
+++ b/sample/output/auth/routes/about/generateUrlAbout.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAbout, UrlPartsAbout } from './patternAbout';
-const generateUrlAbout = (urlParts: UrlPartsAbout) => generateUrl(patternAbout, {}, urlParts.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, {}, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/auth/routes/account/LinkAccount.tsx
+++ b/sample/output/auth/routes/account/LinkAccount.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternAccount } from './patternAccount';
-type LinkAccountProps = Omit<AnchorProps, 'href'>;
+import { patternAccount, UrlPartsAccount } from './patternAccount';
+type LinkAccountProps = Omit<AnchorProps, 'href'> & UrlPartsAccount;
 const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAccount, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/account/generateUrlAccount.ts
+++ b/sample/output/auth/routes/account/generateUrlAccount.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAccount, UrlPartsAccount } from './patternAccount';
-const generateUrlAccount = (urlParts: UrlPartsAccount) => generateUrl(patternAccount, {}, urlParts.urlQuery);
+const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/auth/routes/home/LinkHome.tsx
+++ b/sample/output/auth/routes/home/LinkHome.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternHome } from './patternHome';
-type LinkHomeProps = Omit<AnchorProps, 'href'>;
+import { patternHome, UrlPartsHome } from './patternHome';
+type LinkHomeProps = Omit<AnchorProps, 'href'> & UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternHome, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/home/generateUrlHome.ts
+++ b/sample/output/auth/routes/home/generateUrlHome.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternHome, UrlPartsHome } from './patternHome';
-const generateUrlHome = (urlParts: UrlPartsHome) => generateUrl(patternHome, {}, urlParts.urlQuery);
+const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/auth/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/auth/routes/legacy/LinkLegacy.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternLegacy } from './patternLegacy';
-type LinkLegacyProps = Omit<AnchorProps, 'href'>;
+import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
+type LinkLegacyProps = Omit<AnchorProps, 'href'> & UrlPartsLegacy;
 const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLegacy, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/auth/routes/legacy/generateUrlLegacy.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
-const generateUrlLegacy = (urlParts: UrlPartsLegacy) => generateUrl(patternLegacy, {}, urlParts.urlQuery);
+const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/auth/routes/login/LinkLogin.tsx
+++ b/sample/output/auth/routes/login/LinkLogin.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { LinkProps } from 'common/components/Link';
-import { patternLogin } from './patternLogin';
-type LinkLoginProps = Omit<LinkProps, 'to'>;
+import { patternLogin, UrlPartsLogin } from './patternLogin';
+type LinkLoginProps = Omit<LinkProps, 'to'> & UrlPartsLogin;
 const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLogin, {}, urlQuery);
   return <Link {...props} to={to} />;

--- a/sample/output/auth/routes/login/generateUrlLogin.ts
+++ b/sample/output/auth/routes/login/generateUrlLogin.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLogin, UrlPartsLogin } from './patternLogin';
-const generateUrlLogin = (urlParts: UrlPartsLogin) => generateUrl(patternLogin, {}, urlParts.urlQuery);
+const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/auth/routes/signup/LinkSignup.tsx
+++ b/sample/output/auth/routes/signup/LinkSignup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { LinkProps } from 'common/components/Link';
-import { patternSignup } from './patternSignup';
-type LinkSignupProps = Omit<LinkProps, 'to'>;
+import { patternSignup, UrlPartsSignup } from './patternSignup';
+type LinkSignupProps = Omit<LinkProps, 'to'> & UrlPartsSignup;
 const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternSignup, {}, urlQuery);
   return <Link {...props} to={to} />;

--- a/sample/output/auth/routes/signup/generateUrlSignup.ts
+++ b/sample/output/auth/routes/signup/generateUrlSignup.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternSignup, UrlPartsSignup } from './patternSignup';
-const generateUrlSignup = (urlParts: UrlPartsSignup) => generateUrl(patternSignup, {}, urlParts.urlQuery);
+const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/auth/routes/toc/LinkToc.tsx
+++ b/sample/output/auth/routes/toc/LinkToc.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternToc } from './patternToc';
-type LinkTocProps = Omit<AnchorProps, 'href'>;
+import { patternToc, UrlPartsToc } from './patternToc';
+type LinkTocProps = Omit<AnchorProps, 'href'> & UrlPartsToc;
 const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternToc, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/toc/generateUrlToc.ts
+++ b/sample/output/auth/routes/toc/generateUrlToc.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternToc, UrlPartsToc } from './patternToc';
-const generateUrlToc = (urlParts: UrlPartsToc) => generateUrl(patternToc, {}, urlParts.urlQuery);
+const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/auth/routes/user/LinkUser.tsx
+++ b/sample/output/auth/routes/user/LinkUser.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import { AnchorProps, CustomAnchor as Link } from 'common/ui/Anchor';
-import { patternUser } from './patternUser';
-type LinkUserProps = Omit<AnchorProps, 'href'>;
+import { patternUser, UrlPartsUser } from './patternUser';
+type LinkUserProps = Omit<AnchorProps, 'href'> & UrlPartsUser;
 const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
   const to = generateUrl(patternUser, path, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/auth/routes/user/generateUrlUser.ts
+++ b/sample/output/auth/routes/user/generateUrlUser.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternUser, UrlPartsUser } from './patternUser';
-const generateUrlUser = (urlParts: UrlPartsUser) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/seo/routes/about/LinkAbout.tsx
+++ b/sample/output/seo/routes/about/LinkAbout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { LinkProps } from 'next/link';
-import { patternAbout } from './patternAbout';
-type LinkAboutProps = Omit<LinkProps, 'href'>;
+import { patternAbout, UrlPartsAbout } from './patternAbout';
+type LinkAboutProps = Omit<LinkProps, 'href'> & UrlPartsAbout;
 const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAbout, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/seo/routes/about/generateUrlAbout.ts
+++ b/sample/output/seo/routes/about/generateUrlAbout.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAbout, UrlPartsAbout } from './patternAbout';
-const generateUrlAbout = (urlParts: UrlPartsAbout) => generateUrl(patternAbout, {}, urlParts.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, {}, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/seo/routes/account/LinkAccount.tsx
+++ b/sample/output/seo/routes/account/LinkAccount.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternAccount } from './patternAccount';
+import { patternAccount, UrlPartsAccount } from './patternAccount';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsAccount;
 const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAccount, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/account/generateUrlAccount.ts
+++ b/sample/output/seo/routes/account/generateUrlAccount.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAccount, UrlPartsAccount } from './patternAccount';
-const generateUrlAccount = (urlParts: UrlPartsAccount) => generateUrl(patternAccount, {}, urlParts.urlQuery);
+const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/seo/routes/home/LinkHome.tsx
+++ b/sample/output/seo/routes/home/LinkHome.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { LinkProps } from 'next/link';
-import { patternHome } from './patternHome';
-type LinkHomeProps = Omit<LinkProps, 'href'>;
+import { patternHome, UrlPartsHome } from './patternHome';
+type LinkHomeProps = Omit<LinkProps, 'href'> & UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternHome, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/seo/routes/home/generateUrlHome.ts
+++ b/sample/output/seo/routes/home/generateUrlHome.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternHome, UrlPartsHome } from './patternHome';
-const generateUrlHome = (urlParts: UrlPartsHome) => generateUrl(patternHome, {}, urlParts.urlQuery);
+const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/seo/routes/legacy/LinkLegacy.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternLegacy } from './patternLegacy';
+import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsLegacy;
 const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLegacy, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/seo/routes/legacy/generateUrlLegacy.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
-const generateUrlLegacy = (urlParts: UrlPartsLegacy) => generateUrl(patternLegacy, {}, urlParts.urlQuery);
+const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/seo/routes/login/LinkLogin.tsx
+++ b/sample/output/seo/routes/login/LinkLogin.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternLogin } from './patternLogin';
+import { patternLogin, UrlPartsLogin } from './patternLogin';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsLogin;
 const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLogin, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/login/generateUrlLogin.ts
+++ b/sample/output/seo/routes/login/generateUrlLogin.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLogin, UrlPartsLogin } from './patternLogin';
-const generateUrlLogin = (urlParts: UrlPartsLogin) => generateUrl(patternLogin, {}, urlParts.urlQuery);
+const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/seo/routes/signup/LinkSignup.tsx
+++ b/sample/output/seo/routes/signup/LinkSignup.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternSignup } from './patternSignup';
+import { patternSignup, UrlPartsSignup } from './patternSignup';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsSignup;
 const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternSignup, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/signup/generateUrlSignup.ts
+++ b/sample/output/seo/routes/signup/generateUrlSignup.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternSignup, UrlPartsSignup } from './patternSignup';
-const generateUrlSignup = (urlParts: UrlPartsSignup) => generateUrl(patternSignup, {}, urlParts.urlQuery);
+const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/seo/routes/toc/LinkToc.tsx
+++ b/sample/output/seo/routes/toc/LinkToc.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternToc } from './patternToc';
+import { patternToc, UrlPartsToc } from './patternToc';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsToc;
 const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternToc, {}, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/toc/generateUrlToc.ts
+++ b/sample/output/seo/routes/toc/generateUrlToc.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternToc, UrlPartsToc } from './patternToc';
-const generateUrlToc = (urlParts: UrlPartsToc) => generateUrl(patternToc, {}, urlParts.urlQuery);
+const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/seo/routes/user/LinkUser.tsx
+++ b/sample/output/seo/routes/user/LinkUser.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 
-import { patternUser } from './patternUser';
+import { patternUser, UrlPartsUser } from './patternUser';
 type LinkProps = Omit<
   React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
   'href'
->;
+> &
+  UrlPartsUser;
 const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, ...props }) => {
   const to = generateUrl(patternUser, path, urlQuery);
   return <a {...props} href={to} />;

--- a/sample/output/seo/routes/user/generateUrlUser.ts
+++ b/sample/output/seo/routes/user/generateUrlUser.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternUser, UrlPartsUser } from './patternUser';
-const generateUrlUser = (urlParts: UrlPartsUser) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/server/routes/about/generateUrlAbout.ts
+++ b/sample/output/server/routes/about/generateUrlAbout.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAbout, UrlPartsAbout } from './patternAbout';
-const generateUrlAbout = (urlParts: UrlPartsAbout) => generateUrl(patternAbout, {}, urlParts.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, {}, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/server/routes/account/generateUrlAccount.ts
+++ b/sample/output/server/routes/account/generateUrlAccount.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAccount, UrlPartsAccount } from './patternAccount';
-const generateUrlAccount = (urlParts: UrlPartsAccount) => generateUrl(patternAccount, {}, urlParts.urlQuery);
+const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/server/routes/home/generateUrlHome.ts
+++ b/sample/output/server/routes/home/generateUrlHome.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternHome, UrlPartsHome } from './patternHome';
-const generateUrlHome = (urlParts: UrlPartsHome) => generateUrl(patternHome, {}, urlParts.urlQuery);
+const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/server/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/server/routes/legacy/generateUrlLegacy.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
-const generateUrlLegacy = (urlParts: UrlPartsLegacy) => generateUrl(patternLegacy, {}, urlParts.urlQuery);
+const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/server/routes/login/generateUrlLogin.ts
+++ b/sample/output/server/routes/login/generateUrlLogin.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLogin, UrlPartsLogin } from './patternLogin';
-const generateUrlLogin = (urlParts: UrlPartsLogin) => generateUrl(patternLogin, {}, urlParts.urlQuery);
+const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/server/routes/signup/generateUrlSignup.ts
+++ b/sample/output/server/routes/signup/generateUrlSignup.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternSignup, UrlPartsSignup } from './patternSignup';
-const generateUrlSignup = (urlParts: UrlPartsSignup) => generateUrl(patternSignup, {}, urlParts.urlQuery);
+const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/server/routes/toc/generateUrlToc.ts
+++ b/sample/output/server/routes/toc/generateUrlToc.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternToc, UrlPartsToc } from './patternToc';
-const generateUrlToc = (urlParts: UrlPartsToc) => generateUrl(patternToc, {}, urlParts.urlQuery);
+const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/server/routes/user/generateUrlUser.ts
+++ b/sample/output/server/routes/user/generateUrlUser.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternUser, UrlPartsUser } from './patternUser';
-const generateUrlUser = (urlParts: UrlPartsUser) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/toc/routes/about/LinkAbout.tsx
+++ b/sample/output/toc/routes/about/LinkAbout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternAbout } from './patternAbout';
-type LinkAboutProps = Omit<AnchorProps, 'href'>;
+import { patternAbout, UrlPartsAbout } from './patternAbout';
+type LinkAboutProps = Omit<AnchorProps, 'href'> & UrlPartsAbout;
 const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAbout, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/about/generateUrlAbout.ts
+++ b/sample/output/toc/routes/about/generateUrlAbout.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAbout, UrlPartsAbout } from './patternAbout';
-const generateUrlAbout = (urlParts: UrlPartsAbout) => generateUrl(patternAbout, {}, urlParts.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, {}, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/toc/routes/account/LinkAccount.tsx
+++ b/sample/output/toc/routes/account/LinkAccount.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternAccount } from './patternAccount';
-type LinkAccountProps = Omit<AnchorProps, 'href'>;
+import { patternAccount, UrlPartsAccount } from './patternAccount';
+type LinkAccountProps = Omit<AnchorProps, 'href'> & UrlPartsAccount;
 const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternAccount, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/account/generateUrlAccount.ts
+++ b/sample/output/toc/routes/account/generateUrlAccount.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternAccount, UrlPartsAccount } from './patternAccount';
-const generateUrlAccount = (urlParts: UrlPartsAccount) => generateUrl(patternAccount, {}, urlParts.urlQuery);
+const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/toc/routes/home/LinkHome.tsx
+++ b/sample/output/toc/routes/home/LinkHome.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternHome } from './patternHome';
-type LinkHomeProps = Omit<AnchorProps, 'href'>;
+import { patternHome, UrlPartsHome } from './patternHome';
+type LinkHomeProps = Omit<AnchorProps, 'href'> & UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternHome, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/home/generateUrlHome.ts
+++ b/sample/output/toc/routes/home/generateUrlHome.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternHome, UrlPartsHome } from './patternHome';
-const generateUrlHome = (urlParts: UrlPartsHome) => generateUrl(patternHome, {}, urlParts.urlQuery);
+const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/toc/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/toc/routes/legacy/LinkLegacy.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternLegacy } from './patternLegacy';
-type LinkLegacyProps = Omit<AnchorProps, 'href'>;
+import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
+type LinkLegacyProps = Omit<AnchorProps, 'href'> & UrlPartsLegacy;
 const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLegacy, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/toc/routes/legacy/generateUrlLegacy.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLegacy, UrlPartsLegacy } from './patternLegacy';
-const generateUrlLegacy = (urlParts: UrlPartsLegacy) => generateUrl(patternLegacy, {}, urlParts.urlQuery);
+const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/toc/routes/login/LinkLogin.tsx
+++ b/sample/output/toc/routes/login/LinkLogin.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternLogin } from './patternLogin';
-type LinkLoginProps = Omit<AnchorProps, 'href'>;
+import { patternLogin, UrlPartsLogin } from './patternLogin';
+type LinkLoginProps = Omit<AnchorProps, 'href'> & UrlPartsLogin;
 const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternLogin, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/login/generateUrlLogin.ts
+++ b/sample/output/toc/routes/login/generateUrlLogin.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternLogin, UrlPartsLogin } from './patternLogin';
-const generateUrlLogin = (urlParts: UrlPartsLogin) => generateUrl(patternLogin, {}, urlParts.urlQuery);
+const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/toc/routes/signup/LinkSignup.tsx
+++ b/sample/output/toc/routes/signup/LinkSignup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternSignup } from './patternSignup';
-type LinkSignupProps = Omit<AnchorProps, 'href'>;
+import { patternSignup, UrlPartsSignup } from './patternSignup';
+type LinkSignupProps = Omit<AnchorProps, 'href'> & UrlPartsSignup;
 const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternSignup, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/signup/generateUrlSignup.ts
+++ b/sample/output/toc/routes/signup/generateUrlSignup.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternSignup, UrlPartsSignup } from './patternSignup';
-const generateUrlSignup = (urlParts: UrlPartsSignup) => generateUrl(patternSignup, {}, urlParts.urlQuery);
+const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/toc/routes/toc/LinkToc.tsx
+++ b/sample/output/toc/routes/toc/LinkToc.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { LinkProps } from 'src/common/components/Link';
-import { patternToc } from './patternToc';
-type LinkTocProps = Omit<LinkProps, 'href'>;
+import { patternToc, UrlPartsToc } from './patternToc';
+type LinkTocProps = Omit<LinkProps, 'href'> & UrlPartsToc;
 const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, ...props }) => {
   const to = generateUrl(patternToc, {}, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/toc/generateUrlToc.ts
+++ b/sample/output/toc/routes/toc/generateUrlToc.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternToc, UrlPartsToc } from './patternToc';
-const generateUrlToc = (urlParts: UrlPartsToc) => generateUrl(patternToc, {}, urlParts.urlQuery);
+const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/toc/routes/user/LinkUser.tsx
+++ b/sample/output/toc/routes/user/LinkUser.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { generateUrl } from 'route-codegen';
 import Link, { AnchorProps } from 'src/common/ui/Anchor';
-import { patternUser } from './patternUser';
-type LinkUserProps = Omit<AnchorProps, 'href'>;
+import { patternUser, UrlPartsUser } from './patternUser';
+type LinkUserProps = Omit<AnchorProps, 'href'> & UrlPartsUser;
 const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
   const to = generateUrl(patternUser, path, urlQuery);
   return <Link {...props} href={to} />;

--- a/sample/output/toc/routes/user/generateUrlUser.ts
+++ b/sample/output/toc/routes/user/generateUrlUser.ts
@@ -1,4 +1,4 @@
 import { generateUrl } from 'route-codegen';
 import { patternUser, UrlPartsUser } from './patternUser';
-const generateUrlUser = (urlParts: UrlPartsUser) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/src/generate/generateAppFiles/generateLinkFile.test.ts
+++ b/src/generate/generateAppFiles/generateLinkFile.test.ts
@@ -22,7 +22,7 @@ describe('generateLinkFile', () => {
         hrefProp: 'href',
         linkComponent: 'a',
         inlineLinkProps: {
-          template: `type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'>;`,
+          template: `type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'>`,
           linkProps: 'InlineLinkProps',
         },
       },
@@ -56,8 +56,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import Link, {CustomLinkProps,} from 'src/common/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'to'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} to={to} />;
@@ -81,8 +81,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import Link, {CustomLinkProps,} from 'src/common/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'to'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, path, urlQuery);
     return <Link {...props} to={to} />;
@@ -116,8 +116,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'to'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} to={to} />;
@@ -136,8 +136,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} customHref={to} />;
@@ -161,8 +161,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, path, urlQuery);
     return <Link {...props} customHref={to} />;
@@ -194,8 +194,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'to'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} to={to} />;
@@ -230,8 +230,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import Link, {CustomLinkProps,} from 'src/Default/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} customDefaultHref={to} />;
@@ -247,9 +247,9 @@ describe('generateLinkFile', () => {
       expect(templateFile.destinationDir).toBe('path/to/routes');
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
-  
-  import {patternLogin,} from './patternLogin'
-  type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'>;
+
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <a {...props} href={to} />;
@@ -273,8 +273,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   
-  import {patternLogin,} from './patternLogin'
-  type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, path, urlQuery);
     return <a {...props} href={to} />;
@@ -306,8 +306,8 @@ describe('generateLinkFile', () => {
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
-  import {patternLogin,} from './patternLogin'
-  type LinkLoginProps = Omit<CustomLinkProps, 'to'>;
+  import {patternLogin,UrlPartsLogin,} from './patternLogin'
+  type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
     const to = generateUrl(patternLogin, {}, urlQuery);
     return <Link {...props} to={to} />;

--- a/src/generate/generateAppFiles/generateLinkFile.test.ts
+++ b/src/generate/generateAppFiles/generateLinkFile.test.ts
@@ -247,7 +247,7 @@ describe('generateLinkFile', () => {
       expect(templateFile.destinationDir).toBe('path/to/routes');
       expect(templateFile.template).toContain(`import React from 'react'
   import {generateUrl,} from 'route-codegen'
-
+  
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  urlQuery, ...props }) => {

--- a/src/generate/generateAppFiles/generateLinkFile.ts
+++ b/src/generate/generateAppFiles/generateLinkFile.ts
@@ -20,7 +20,7 @@ const generateLinkFile: GenerateLinkFile = ({
   routingType,
   routeLinkOptions,
   destinationDir,
-  patternNamedExports: { patternName, pathParamsInterfaceName, filename: routePatternFilename },
+  patternNamedExports: { patternName, pathParamsInterfaceName, filename: routePatternFilename, urlPartsInterfaceName },
   importGenerateUrl,
 }) => {
   const functionName = `Link${routeName}`;
@@ -29,6 +29,7 @@ const generateLinkFile: GenerateLinkFile = ({
 
   const { hrefProp, importLink, linkComponent, linkPropsTemplate, linkPropsInterfaceName } = generateLinkInterface({
     defaultLinkPropsInterfaceName,
+    urlPartsInterfaceName,
     routingType,
     routeLinkOptions,
   });
@@ -36,7 +37,10 @@ const generateLinkFile: GenerateLinkFile = ({
   const template = `${printImport({ defaultImport: 'React', from: 'react' })}
   ${printImport(importGenerateUrl)}
   ${importLink ? printImport(importLink) : ''}
-  ${printImport({ namedImports: [{ name: patternName }], from: `./${routePatternFilename}` })}
+  ${printImport({
+    namedImports: [{ name: patternName }, { name: urlPartsInterfaceName }],
+    from: `./${routePatternFilename}`,
+  })}
   ${linkPropsTemplate}
   const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
     hasPathParams ? 'path,' : ''
@@ -61,6 +65,7 @@ type GenerateLinkInterface = (params: {
   routingType: RoutingType;
   routeLinkOptions: RouteLinkOptions;
   defaultLinkPropsInterfaceName: string;
+  urlPartsInterfaceName: string;
 }) => {
   importLink?: Import;
   linkPropsTemplate: string;
@@ -74,16 +79,17 @@ const generateLinkInterface: GenerateLinkInterface = ({
   routingType,
   routeLinkOptions,
   defaultLinkPropsInterfaceName,
+  urlPartsInterfaceName,
 }) => {
   const option = routeLinkOptions[routingType];
 
   const { hrefProp, linkProps, importLink } = option;
 
   // if there's inlineLinkPropsTemplate, we don't import anything
-  let linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'>;`;
+  let linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'> & ${urlPartsInterfaceName}`;
   let linkPropsInterfaceName = defaultLinkPropsInterfaceName;
   if ('inlineLinkProps' in option && option.inlineLinkProps) {
-    linkPropsTemplate = option.inlineLinkProps.template;
+    linkPropsTemplate = `${option.inlineLinkProps.template} & ${urlPartsInterfaceName}`;
     linkPropsInterfaceName = option.inlineLinkProps.linkProps;
   }
 

--- a/src/generate/generateAppFiles/generateUrlFile.test.ts
+++ b/src/generate/generateAppFiles/generateUrlFile.test.ts
@@ -18,7 +18,7 @@ describe('generateUseParamsFile', () => {
     expect(templateFile.destinationDir).toBe('path/to/routes');
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,} from './patternUser'
-  const generateUrlUser = ( urlParts: UrlPartsUser ) => generateUrl(patternUser, {}, urlParts.urlQuery);
+  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, {}, urlParts.urlQuery);
   export default generateUrlUser;`);
   });
 
@@ -40,7 +40,7 @@ describe('generateUseParamsFile', () => {
     expect(templateFile.destinationDir).toBe('path/to/routes');
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,} from './patternUser'
-  const generateUrlUser = ( urlParts: UrlPartsUser ) => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
   export default generateUrlUser;`);
   });
 });

--- a/src/generate/generateAppFiles/generateUrlFile.ts
+++ b/src/generate/generateAppFiles/generateUrlFile.ts
@@ -23,7 +23,7 @@ const generateUrlFile: GenerateUrlFile = ({
     namedImports: [{ name: patternName }, { name: urlPartsInterfaceName }],
     from: `./${filename}`,
   })}
-  const ${functionName} = ( urlParts: ${urlPartsInterfaceName} ) => generateUrl(${patternName}, ${pathVariable}, urlParts.urlQuery);
+  const ${functionName} = ( urlParts: ${urlPartsInterfaceName} ): string => generateUrl(${patternName}, ${pathVariable}, urlParts.urlQuery);
   export default ${functionName};
   `;
 

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -16,8 +16,7 @@ describe('parseAppConfig', () => {
   const defaultParsedReactRouterV5RouteLinkOptions: ParsedReactRouterV5LinkOptions = {
     importLink: {
       from: 'react-router-dom',
-      defaultImport: 'Link',
-      namedImports: [{ name: 'LinkProps' }],
+      namedImports: [{ name: 'LinkProps' }, { name: 'Link' }],
     },
     linkComponent: 'Link',
     linkProps: 'LinkProps',

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -38,7 +38,7 @@ describe('parseAppConfig', () => {
     hrefProp: 'href',
     linkComponent: 'a',
     inlineLinkProps: {
-      template: `type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'href'>;`,
+      template: `type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'href'>`,
       linkProps: 'LinkProps',
     },
   };

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -73,7 +73,7 @@ describe('parseAppConfig', () => {
       expect(() =>
         parseAppConfig('sampleApp', { ...defaultAppConfig, routingType: 'WRONG_ROUTING_TYPE' })
       ).toThrowError(
-        'sampleApp.routingType - Routing type of an app must be either "NextJS" or "ReactRouter" or "Default"'
+        'sampleApp.routingType - Routing type of an app must be either "NextJS" or "ReactRouterV5" or "Default"'
       );
     });
 

--- a/src/generate/generateAppFiles/parseAppConfig.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.ts
@@ -70,7 +70,7 @@ const parseAppConfig = (
   ) {
     return throwError(
       [appName, 'routingType'],
-      'Routing type of an app must be either "NextJS" or "ReactRouter" or "Default"'
+      `Routing type of an app must be either "${RoutingType.NextJS}" or "${RoutingType.ReactRouterV5}" or "${RoutingType.Default}"`
     );
   }
 

--- a/src/generate/generateAppFiles/parseAppConfig.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.ts
@@ -174,7 +174,7 @@ const prepareDefaultLinkOptions = (
     hrefProp: 'href',
     linkComponent: 'a',
     inlineLinkProps: {
-      template: `type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'href'>;`,
+      template: `type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'href'>`,
       linkProps: 'LinkProps',
     },
   };

--- a/src/generate/generateAppFiles/parseAppConfig.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.ts
@@ -97,8 +97,7 @@ const prepareReactRouterV5LinkOptions = (
   const defaultOptions: ParsedReactRouterV5LinkOptions = {
     importLink: {
       from: 'react-router-dom',
-      defaultImport: 'Link',
-      namedImports: [{ name: 'LinkProps' }],
+      namedImports: [{ name: 'LinkProps' }, { name: 'Link' }],
     },
     linkComponent: 'Link',
     linkProps: 'LinkProps',


### PR DESCRIPTION
* Fix error message if wrong routingType is supplied
* Fix import issue of react router v5 Link component
* Add return type to template of generateUrlFile
* Update samples
* Fix generateLinkFile to import urlParts correctly
* Fix parseAppConfig to handle default ReactRouterV5 Link import correctly
* Add homepage, bugs and repository fields to package.json

