### PR TITLE
Fix UrlParts generated templates

### DIFF
--- a/sample/output/app/routes/about/patternAbout.ts
+++ b/sample/output/app/routes/about/patternAbout.ts
@@ -1,5 +1,5 @@
 export const patternAbout = '/about';
 
 export interface UrlPartsAbout {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/account/patternAccount.ts
+++ b/sample/output/app/routes/account/patternAccount.ts
@@ -1,5 +1,5 @@
 export const patternAccount = '/app/account';
 
 export interface UrlPartsAccount {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/home/patternHome.ts
+++ b/sample/output/app/routes/home/patternHome.ts
@@ -1,5 +1,5 @@
 export const patternHome = '/';
 
 export interface UrlPartsHome {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/legacy/patternLegacy.ts
+++ b/sample/output/app/routes/legacy/patternLegacy.ts
@@ -1,5 +1,5 @@
 export const patternLegacy = '/legacy/app';
 
 export interface UrlPartsLegacy {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/login/patternLogin.ts
+++ b/sample/output/app/routes/login/patternLogin.ts
@@ -1,5 +1,5 @@
 export const patternLogin = '/login';
 
 export interface UrlPartsLogin {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/signup/patternSignup.ts
+++ b/sample/output/app/routes/signup/patternSignup.ts
@@ -1,5 +1,5 @@
 export const patternSignup = '/signup';
 
 export interface UrlPartsSignup {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/toc/patternToc.ts
+++ b/sample/output/app/routes/toc/patternToc.ts
@@ -1,5 +1,5 @@
 export const patternToc = '/terms-and-conditions';
 
 export interface UrlPartsToc {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/app/routes/user/patternUser.ts
+++ b/sample/output/app/routes/user/patternUser.ts
@@ -6,5 +6,5 @@ export interface PathParamsUser {
 
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/about/patternAbout.ts
+++ b/sample/output/auth/routes/about/patternAbout.ts
@@ -1,5 +1,5 @@
 export const patternAbout = '/about';
 
 export interface UrlPartsAbout {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/account/patternAccount.ts
+++ b/sample/output/auth/routes/account/patternAccount.ts
@@ -1,5 +1,5 @@
 export const patternAccount = '/app/account';
 
 export interface UrlPartsAccount {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/home/patternHome.ts
+++ b/sample/output/auth/routes/home/patternHome.ts
@@ -1,5 +1,5 @@
 export const patternHome = '/';
 
 export interface UrlPartsHome {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/legacy/patternLegacy.ts
+++ b/sample/output/auth/routes/legacy/patternLegacy.ts
@@ -1,5 +1,5 @@
 export const patternLegacy = '/legacy/app';
 
 export interface UrlPartsLegacy {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/login/patternLogin.ts
+++ b/sample/output/auth/routes/login/patternLogin.ts
@@ -1,5 +1,5 @@
 export const patternLogin = '/login';
 
 export interface UrlPartsLogin {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/signup/patternSignup.ts
+++ b/sample/output/auth/routes/signup/patternSignup.ts
@@ -1,5 +1,5 @@
 export const patternSignup = '/signup';
 
 export interface UrlPartsSignup {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/toc/patternToc.ts
+++ b/sample/output/auth/routes/toc/patternToc.ts
@@ -1,5 +1,5 @@
 export const patternToc = '/terms-and-conditions';
 
 export interface UrlPartsToc {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/auth/routes/user/patternUser.ts
+++ b/sample/output/auth/routes/user/patternUser.ts
@@ -6,5 +6,5 @@ export interface PathParamsUser {
 
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/about/patternAbout.ts
+++ b/sample/output/seo/routes/about/patternAbout.ts
@@ -1,5 +1,5 @@
 export const patternAbout = '/about';
 
 export interface UrlPartsAbout {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/account/patternAccount.ts
+++ b/sample/output/seo/routes/account/patternAccount.ts
@@ -1,5 +1,5 @@
 export const patternAccount = '/app/account';
 
 export interface UrlPartsAccount {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/home/patternHome.ts
+++ b/sample/output/seo/routes/home/patternHome.ts
@@ -1,5 +1,5 @@
 export const patternHome = '/';
 
 export interface UrlPartsHome {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output/seo/routes/legacy/patternLegacy.ts
@@ -1,5 +1,5 @@
 export const patternLegacy = '/legacy/app';
 
 export interface UrlPartsLegacy {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/login/patternLogin.ts
+++ b/sample/output/seo/routes/login/patternLogin.ts
@@ -1,5 +1,5 @@
 export const patternLogin = '/login';
 
 export interface UrlPartsLogin {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/signup/patternSignup.ts
+++ b/sample/output/seo/routes/signup/patternSignup.ts
@@ -1,5 +1,5 @@
 export const patternSignup = '/signup';
 
 export interface UrlPartsSignup {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/toc/patternToc.ts
+++ b/sample/output/seo/routes/toc/patternToc.ts
@@ -1,5 +1,5 @@
 export const patternToc = '/terms-and-conditions';
 
 export interface UrlPartsToc {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/seo/routes/user/patternUser.ts
+++ b/sample/output/seo/routes/user/patternUser.ts
@@ -6,5 +6,5 @@ export interface PathParamsUser {
 
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/about/patternAbout.ts
+++ b/sample/output/server/routes/about/patternAbout.ts
@@ -1,5 +1,5 @@
 export const patternAbout = '/about';
 
 export interface UrlPartsAbout {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/account/patternAccount.ts
+++ b/sample/output/server/routes/account/patternAccount.ts
@@ -1,5 +1,5 @@
 export const patternAccount = '/app/account';
 
 export interface UrlPartsAccount {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/home/patternHome.ts
+++ b/sample/output/server/routes/home/patternHome.ts
@@ -1,5 +1,5 @@
 export const patternHome = '/';
 
 export interface UrlPartsHome {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/legacy/patternLegacy.ts
+++ b/sample/output/server/routes/legacy/patternLegacy.ts
@@ -1,5 +1,5 @@
 export const patternLegacy = '/legacy/app';
 
 export interface UrlPartsLegacy {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/login/patternLogin.ts
+++ b/sample/output/server/routes/login/patternLogin.ts
@@ -1,5 +1,5 @@
 export const patternLogin = '/login';
 
 export interface UrlPartsLogin {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/signup/patternSignup.ts
+++ b/sample/output/server/routes/signup/patternSignup.ts
@@ -1,5 +1,5 @@
 export const patternSignup = '/signup';
 
 export interface UrlPartsSignup {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/toc/patternToc.ts
+++ b/sample/output/server/routes/toc/patternToc.ts
@@ -1,5 +1,5 @@
 export const patternToc = '/terms-and-conditions';
 
 export interface UrlPartsToc {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/server/routes/user/patternUser.ts
+++ b/sample/output/server/routes/user/patternUser.ts
@@ -6,5 +6,5 @@ export interface PathParamsUser {
 
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/about/patternAbout.ts
+++ b/sample/output/toc/routes/about/patternAbout.ts
@@ -1,5 +1,5 @@
 export const patternAbout = '/about';
 
 export interface UrlPartsAbout {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/account/patternAccount.ts
+++ b/sample/output/toc/routes/account/patternAccount.ts
@@ -1,5 +1,5 @@
 export const patternAccount = '/app/account';
 
 export interface UrlPartsAccount {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/home/patternHome.ts
+++ b/sample/output/toc/routes/home/patternHome.ts
@@ -1,5 +1,5 @@
 export const patternHome = '/';
 
 export interface UrlPartsHome {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/legacy/patternLegacy.ts
+++ b/sample/output/toc/routes/legacy/patternLegacy.ts
@@ -1,5 +1,5 @@
 export const patternLegacy = '/legacy/app';
 
 export interface UrlPartsLegacy {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/login/patternLogin.ts
+++ b/sample/output/toc/routes/login/patternLogin.ts
@@ -1,5 +1,5 @@
 export const patternLogin = '/login';
 
 export interface UrlPartsLogin {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/signup/patternSignup.ts
+++ b/sample/output/toc/routes/signup/patternSignup.ts
@@ -1,5 +1,5 @@
 export const patternSignup = '/signup';
 
 export interface UrlPartsSignup {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/toc/patternToc.ts
+++ b/sample/output/toc/routes/toc/patternToc.ts
@@ -1,5 +1,5 @@
 export const patternToc = '/terms-and-conditions';
 
 export interface UrlPartsToc {
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/sample/output/toc/routes/user/patternUser.ts
+++ b/sample/output/toc/routes/user/patternUser.ts
@@ -6,5 +6,5 @@ export interface PathParamsUser {
 
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Partial<Record<string, string>>;
+  urlQuery?: Record<string, string>;
 }

--- a/src/generate/generateAppFiles/generatePatternFile.test.ts
+++ b/src/generate/generateAppFiles/generatePatternFile.test.ts
@@ -37,7 +37,7 @@ describe('generatePatternFile', () => {
     );
     expect(templateFile.template).toContain(`export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
-    urlQuery?: Partial<Record<string, string>>;
+    urlQuery?: Record<string, string>;
   }`);
     expect(interfaceResult).toEqual({
       patternName: 'patternUserInfo',

--- a/src/generate/generateAppFiles/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatePatternFile.ts
@@ -93,7 +93,7 @@ const generateUrlPartsInterface = (
 
   const template = `export interface ${interfaceName} {
     ${pathParams ? `path: ${pathParams.interfaceName};` : ''}
-    urlQuery?: Partial<Record<string, string>>;
+    urlQuery?: Record<string, string>;
   }`;
 
   return { template, interfaceName };


### PR DESCRIPTION
Remove `Partial` from UrlQuery since `generateUrl` does not require it