### PR TITLE
Add RedirectServerSide component

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/jest": "^25.1.4",
     "@types/js-yaml": "^3.12.2",
     "@types/node": "^13.1.8",
+    "@types/react": "^16.9.34",
     "@types/yargs": "^15.0.3",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",

--- a/sample/output/app/routes/about/RedirectAbout.tsx
+++ b/sample/output/app/routes/about/RedirectAbout.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAbout, patternAbout } from './patternAbout';
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAbout;

--- a/sample/output/app/routes/home/RedirectHome.tsx
+++ b/sample/output/app/routes/home/RedirectHome.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsHome, patternHome } from './patternHome';
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternHome, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectHome;

--- a/sample/output/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/app/routes/legacy/RedirectLegacy.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLegacy, patternLegacy } from './patternLegacy';
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLegacy;

--- a/sample/output/app/routes/login/RedirectLogin.tsx
+++ b/sample/output/app/routes/login/RedirectLogin.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLogin, patternLogin } from './patternLogin';
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLogin;

--- a/sample/output/app/routes/signup/RedirectSignup.tsx
+++ b/sample/output/app/routes/signup/RedirectSignup.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsSignup, patternSignup } from './patternSignup';
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectSignup;

--- a/sample/output/app/routes/toc/RedirectToc.tsx
+++ b/sample/output/app/routes/toc/RedirectToc.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsToc, patternToc } from './patternToc';
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternToc, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectToc;

--- a/sample/output/auth/routes/about/RedirectAbout.tsx
+++ b/sample/output/auth/routes/about/RedirectAbout.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAbout, patternAbout } from './patternAbout';
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAbout;

--- a/sample/output/auth/routes/account/RedirectAccount.tsx
+++ b/sample/output/auth/routes/account/RedirectAccount.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAccount, patternAccount } from './patternAccount';
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAccount;

--- a/sample/output/auth/routes/home/RedirectHome.tsx
+++ b/sample/output/auth/routes/home/RedirectHome.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsHome, patternHome } from './patternHome';
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternHome, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectHome;

--- a/sample/output/auth/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/auth/routes/legacy/RedirectLegacy.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLegacy, patternLegacy } from './patternLegacy';
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLegacy;

--- a/sample/output/auth/routes/toc/RedirectToc.tsx
+++ b/sample/output/auth/routes/toc/RedirectToc.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsToc, patternToc } from './patternToc';
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternToc, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectToc;

--- a/sample/output/auth/routes/user/RedirectUser.tsx
+++ b/sample/output/auth/routes/user/RedirectUser.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsUser, patternUser } from './patternUser';
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectUser;

--- a/sample/output/seo/routes/account/RedirectAccount.tsx
+++ b/sample/output/seo/routes/account/RedirectAccount.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAccount, patternAccount } from './patternAccount';
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAccount;

--- a/sample/output/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/seo/routes/legacy/RedirectLegacy.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLegacy, patternLegacy } from './patternLegacy';
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLegacy;

--- a/sample/output/seo/routes/login/RedirectLogin.tsx
+++ b/sample/output/seo/routes/login/RedirectLogin.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLogin, patternLogin } from './patternLogin';
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLogin;

--- a/sample/output/seo/routes/signup/RedirectSignup.tsx
+++ b/sample/output/seo/routes/signup/RedirectSignup.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsSignup, patternSignup } from './patternSignup';
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectSignup;

--- a/sample/output/seo/routes/toc/RedirectToc.tsx
+++ b/sample/output/seo/routes/toc/RedirectToc.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsToc, patternToc } from './patternToc';
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternToc, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectToc;

--- a/sample/output/seo/routes/user/RedirectUser.tsx
+++ b/sample/output/seo/routes/user/RedirectUser.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsUser, patternUser } from './patternUser';
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectUser;

--- a/sample/output/server/routes/about/RedirectAbout.tsx
+++ b/sample/output/server/routes/about/RedirectAbout.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAbout, patternAbout } from './patternAbout';
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAbout;

--- a/sample/output/server/routes/account/RedirectAccount.tsx
+++ b/sample/output/server/routes/account/RedirectAccount.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAccount, patternAccount } from './patternAccount';
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAccount;

--- a/sample/output/server/routes/home/RedirectHome.tsx
+++ b/sample/output/server/routes/home/RedirectHome.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsHome, patternHome } from './patternHome';
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternHome, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectHome;

--- a/sample/output/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/server/routes/legacy/RedirectLegacy.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLegacy, patternLegacy } from './patternLegacy';
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLegacy;

--- a/sample/output/server/routes/login/RedirectLogin.tsx
+++ b/sample/output/server/routes/login/RedirectLogin.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLogin, patternLogin } from './patternLogin';
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLogin;

--- a/sample/output/server/routes/signup/RedirectSignup.tsx
+++ b/sample/output/server/routes/signup/RedirectSignup.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsSignup, patternSignup } from './patternSignup';
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectSignup;

--- a/sample/output/server/routes/toc/RedirectToc.tsx
+++ b/sample/output/server/routes/toc/RedirectToc.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsToc, patternToc } from './patternToc';
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternToc, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectToc;

--- a/sample/output/server/routes/user/RedirectUser.tsx
+++ b/sample/output/server/routes/user/RedirectUser.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsUser, patternUser } from './patternUser';
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectUser;

--- a/sample/output/toc/routes/about/RedirectAbout.tsx
+++ b/sample/output/toc/routes/about/RedirectAbout.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAbout, patternAbout } from './patternAbout';
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAbout;

--- a/sample/output/toc/routes/account/RedirectAccount.tsx
+++ b/sample/output/toc/routes/account/RedirectAccount.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsAccount, patternAccount } from './patternAccount';
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectAccount;

--- a/sample/output/toc/routes/home/RedirectHome.tsx
+++ b/sample/output/toc/routes/home/RedirectHome.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsHome, patternHome } from './patternHome';
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternHome, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectHome;

--- a/sample/output/toc/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/toc/routes/legacy/RedirectLegacy.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLegacy, patternLegacy } from './patternLegacy';
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLegacy;

--- a/sample/output/toc/routes/login/RedirectLogin.tsx
+++ b/sample/output/toc/routes/login/RedirectLogin.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsLogin, patternLogin } from './patternLogin';
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectLogin;

--- a/sample/output/toc/routes/signup/RedirectSignup.tsx
+++ b/sample/output/toc/routes/signup/RedirectSignup.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsSignup, patternSignup } from './patternSignup';
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectSignup;

--- a/sample/output/toc/routes/user/RedirectUser.tsx
+++ b/sample/output/toc/routes/user/RedirectUser.tsx
@@ -1,14 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import React, { useEffect } from 'react';
+import React from 'react';
+import RedirectServerSide from 'route-codegen/RedirectServerSide';
 import { generateUrl } from 'route-codegen';
 import { UrlPartsUser, patternUser } from './patternUser';
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = props => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);
-  useEffect(() => {
-    if (window && window.location) {
-      window.location.href = to;
-    }
-  }, [to]);
-  return <>{props.fallback}</>;
+  return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
 };
 export default RedirectUser;

--- a/src/RedirectServerSide/RedirectServerSide.tsx
+++ b/src/RedirectServerSide/RedirectServerSide.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+
+export interface RedirectServerSideProps {
+  href: string;
+  fallback?: React.ReactNode;
+}
+
+const RedirectServerSide: React.FunctionComponent<RedirectServerSideProps> = ({ href, fallback }) => {
+  useEffect(() => {
+    if (window && window.location) {
+      window.location.href = href;
+    }
+  }, [href]);
+
+  return <>{fallback}</>;
+};
+
+export default RedirectServerSide;

--- a/src/RedirectServerSide/index.ts
+++ b/src/RedirectServerSide/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RedirectServerSide';
+export * from './RedirectServerSide';

--- a/src/generate/generateAppFiles/generateAppFiles.ts
+++ b/src/generate/generateAppFiles/generateAppFiles.ts
@@ -5,7 +5,14 @@ import parseAppConfig from './parseAppConfig';
 import info from '../utils/info';
 
 const generateAppFiles = (appName: string, app: AppConfig): TemplateFile[] => {
-  const { routes, routingType, destinationDir, routeLinkOptions, importGenerateUrl } = parseAppConfig(appName, app);
+  const {
+    routes,
+    routingType,
+    destinationDir,
+    routeLinkOptions,
+    importGenerateUrl,
+    importRedirectServerSide,
+  } = parseAppConfig(appName, app);
 
   if (destinationDir) {
     const files: TemplateFile[][] = Object.entries(routes).map(([routeName, routePattern]) =>
@@ -16,6 +23,7 @@ const generateAppFiles = (appName: string, app: AppConfig): TemplateFile[] => {
         destinationDir,
         routingType,
         importGenerateUrl,
+        importRedirectServerSide,
       })
     );
     const filesToGenerate = files.flat();

--- a/src/generate/generateAppFiles/generateTemplateFiles.test.ts
+++ b/src/generate/generateAppFiles/generateTemplateFiles.test.ts
@@ -12,6 +12,10 @@ describe('generateTemplateFiles', () => {
       from: 'route-codegen',
       namedImports: [{ name: 'generateUrl' }],
     },
+    importRedirectServerSide: {
+      from: 'route-codegen/RedirectServerSide',
+      defaultImport: 'RedirectServerSide',
+    },
     destinationDir: 'path/to/routes',
     routeLinkOptions: {
       ReactRouterV5: {

--- a/src/generate/generateAppFiles/generateTemplateFiles.ts
+++ b/src/generate/generateAppFiles/generateTemplateFiles.ts
@@ -13,18 +13,20 @@ export interface GenerateTemplateFilesParams {
   routingType: RoutingType;
   routeLinkOptions: RouteLinkOptions;
   importGenerateUrl: Import;
+  importRedirectServerSide: Import;
 }
 
-type GenerateTemplateFiles = (params: GenerateTemplateFilesParams) => TemplateFile[];
+const generateTemplateFiles = (params: GenerateTemplateFilesParams): TemplateFile[] => {
+  const {
+    routeName: originalRouteName,
+    routePattern,
+    destinationDir: originalDestinationDir,
+    routingType,
+    routeLinkOptions,
+    importGenerateUrl,
+    importRedirectServerSide,
+  } = params;
 
-const generateTemplateFiles: GenerateTemplateFiles = ({
-  routeName: originalRouteName,
-  routePattern,
-  destinationDir: originalDestinationDir,
-  routingType,
-  routeLinkOptions,
-  importGenerateUrl,
-}) => {
   const routeNameString = originalRouteName.toString();
   const routeName = routeNameString[0].toUpperCase() + routeNameString.slice(1);
   const destinationDir = `${originalDestinationDir}/${originalRouteName}`;
@@ -138,6 +140,7 @@ const generateTemplateFiles: GenerateTemplateFiles = ({
           destinationDir,
           importGenerateUrl,
           patternNamedExports,
+          importRedirectServerSide,
         });
         files.push(redirectFile);
       }

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
@@ -3,6 +3,7 @@ import generateRedirectFileDefault, { GenerateRedirectFileDefaultParams } from '
 describe('generateRedirectFileDefault', () => {
   const defaultParams: GenerateRedirectFileDefaultParams = {
     importGenerateUrl: { namedImports: [{ name: 'generateUrl' }], from: 'route-codegen' },
+    importRedirectServerSide: { defaultImport: 'RedirectServerSide', from: 'route-codegen/RedirectServerSide' },
     routeName: 'Login',
     patternNamedExports: {
       filename: 'patternLogin',
@@ -19,17 +20,13 @@ describe('generateRedirectFileDefault', () => {
     expect(templateFile.filename).toBe('RedirectLogin');
     expect(templateFile.extension).toBe('.tsx');
     expect(templateFile.destinationDir).toBe('path/to/routes');
-    expect(templateFile.template).toContain(`import React, {useEffect,} from 'react'
+    expect(templateFile.template).toContain(`import React from 'react'
+  import RedirectServerSide from 'route-codegen/RedirectServerSide'
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
     const to = generateUrl(patternLogin, {}, props.urlQuery);
-    useEffect(() => {
-      if (window && window.location) {
-        window.location.href = to;
-      }
-    }, [to]);
-    return <>{props.fallback}</>;
+    return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
   };
   export default RedirectLogin`);
   });
@@ -46,17 +43,13 @@ describe('generateRedirectFileDefault', () => {
     expect(templateFile.filename).toBe('RedirectLogin');
     expect(templateFile.extension).toBe('.tsx');
     expect(templateFile.destinationDir).toBe('path/to/routes');
-    expect(templateFile.template).toContain(`import React, {useEffect,} from 'react'
+    expect(templateFile.template).toContain(`import React from 'react'
+  import RedirectServerSide from 'route-codegen/RedirectServerSide'
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
     const to = generateUrl(patternLogin, props.path, props.urlQuery);
-    useEffect(() => {
-      if (window && window.location) {
-        window.location.href = to;
-      }
-    }, [to]);
-    return <>{props.fallback}</>;
+    return <RedirectServerSide>{props.fallback}</RedirectServerSide>;
   };
   export default RedirectLogin`);
   });

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
@@ -5,17 +5,19 @@ import { PatternNamedExports } from '../types';
 export interface GenerateRedirectFileDefaultParams {
   routeName: string;
   destinationDir: string;
-  importGenerateUrl: Import;
   patternNamedExports: PatternNamedExports;
+  importGenerateUrl: Import;
+  importRedirectServerSide: Import;
 }
 
 const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultParams): TemplateFile => {
-  const { routeName, destinationDir, importGenerateUrl, patternNamedExports } = params;
+  const { routeName, destinationDir, importGenerateUrl, patternNamedExports, importRedirectServerSide } = params;
 
   const functionName = `Redirect${routeName}`;
   const hasPathParams = !!patternNamedExports.pathParamsInterfaceName;
 
-  const template = `${printImport({ defaultImport: 'React', namedImports: [{ name: 'useEffect' }], from: 'react' })}
+  const template = `${printImport({ defaultImport: 'React', from: 'react' })}
+  ${printImport(importRedirectServerSide)}
   ${printImport(importGenerateUrl)}
   ${printImport({
     namedImports: [{ name: patternNamedExports.urlPartsInterfaceName }, { name: patternNamedExports.patternName }],
@@ -25,12 +27,7 @@ const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultParams):
     patternNamedExports.urlPartsInterfaceName
   } & { fallback?: React.ReactNode }> = props => {
     const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? 'props.path' : '{}'}, props.urlQuery);
-    useEffect(() => {
-      if (window && window.location) {
-        window.location.href = to;
-      }
-    }, [to]);
-    return <>{props.fallback}</>;
+    return <${importRedirectServerSide.defaultImport}>{props.fallback}</${importRedirectServerSide.defaultImport}>;
   };
   export default ${functionName}`;
 

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -62,6 +62,7 @@ describe('parseAppConfig', () => {
         destinationDir: 'path/to/routes',
         routingType: RoutingType.Default,
         importGenerateUrl: { from: 'route-codegen', namedImports: [{ name: 'generateUrl' }] },
+        importRedirectServerSide: { from: 'route-codegen/RedirectServerSide', defaultImport: 'RedirectServerSide' },
         routeLinkOptions: {
           ReactRouterV5: { ...defaultParsedLinkOptionsReactRouterV5 },
           NextJS: { ...defaultParsedLinkOptionsNextJS },

--- a/src/generate/generateAppFiles/parseAppConfig.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.ts
@@ -51,6 +51,7 @@ export interface ParsedAppConfig {
   destinationDir?: string;
   routeLinkOptions: RouteLinkOptions;
   importGenerateUrl: Import;
+  importRedirectServerSide: Import;
 }
 
 interface TopLevelGenerateOptions {
@@ -60,9 +61,14 @@ interface TopLevelGenerateOptions {
   generateUseRedirect: boolean;
 }
 
+// Note: these imports are constants at the moment but we could open it up so people can pass their own functions in
 const IMPORT_GENERATE_URL: Import = {
   namedImports: [{ name: 'generateUrl' }],
   from: 'route-codegen',
+};
+const IMPORT_REDIRECT_SERVER_SIDE_COMPONENT: Import = {
+  defaultImport: 'RedirectServerSide',
+  from: 'route-codegen/RedirectServerSide',
 };
 
 const parseAppConfig = (appName: string, appConfig: AppConfig): ParsedAppConfig => {
@@ -111,6 +117,7 @@ const parseAppConfig = (appName: string, appConfig: AppConfig): ParsedAppConfig 
       Default: prepareLinkOptionsDefault({ appName, routeLinkOptions: defaultLinkOptions, topLevelGenerateOptions }),
     },
     importGenerateUrl: IMPORT_GENERATE_URL,
+    importRedirectServerSide: IMPORT_REDIRECT_SERVER_SIDE_COMPONENT,
   };
 
   return parsedConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as generateUrl } from './generateUrl';
+export { default as RedirectServerSide } from './RedirectServerSide';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,31 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "target": "es6",
     "lib": ["es5", "es6", "ES2017", "es2019", "dom", "esnext.asynciterable"],
     "module": "commonjs",
+    "jsx": "preserve",
     "sourceMap": true,
+
     "alwaysStrict": true,
     "noImplicitThis": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
     "removeComments": true,
     "preserveConstEnums": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
-
+    "noImplicitAny": true,
     "esModuleInterop": true,
-    "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "sample/output"]
+  "exclude": ["node_modules", "sample/output", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,6 +367,19 @@
   version "13.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.1.tgz#238eb34a66431b71d2aaddeaa7db166f25971a0d"
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.34":
+  version "16.9.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
+  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -794,6 +807,11 @@ cssstyle@^2.0.0:
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
   dependencies:
     cssom "~0.3.6"
+
+csstype@^2.2.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
## Shared functions / components

- Add `RedirectServerSide` to be used in generated template. This can also be used in apps.

## Template

- Use the shared `RedirectServerSide` components  in generated `Redirect` components of `Default` option instead of inline `useEffect`

## Dependencies

- Add `@types/react` to ensure `RedirectServerSide` type does not complain