### PR TITLE
Import generate url from route codegen

### DIFF
--- a/sample/output/app/routes/about/LinkAbout.tsx
+++ b/sample/output/app/routes/about/LinkAbout.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;

--- a/sample/output/app/routes/about/RedirectAbout.tsx
+++ b/sample/output/app/routes/about/RedirectAbout.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);

--- a/sample/output/app/routes/about/generateUrlAbout.ts
+++ b/sample/output/app/routes/about/generateUrlAbout.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/app/routes/about/useRedirectAbout.ts
+++ b/sample/output/app/routes/about/useRedirectAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectAbout => {
   const redirect: RedirectAbout = (urlParts) => {

--- a/sample/output/app/routes/account/LinkAccount.tsx
+++ b/sample/output/app/routes/account/LinkAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<LinkProps, "to"> & UrlPartsAccount;

--- a/sample/output/app/routes/account/RedirectAccount.tsx
+++ b/sample/output/app/routes/account/RedirectAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {

--- a/sample/output/app/routes/account/generateUrlAccount.ts
+++ b/sample/output/app/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/app/routes/account/useRedirectAccount.ts
+++ b/sample/output/app/routes/account/useRedirectAccount.ts
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useHistory } from "react-router";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectAccount => {
   const history = useHistory();

--- a/sample/output/app/routes/home/LinkHome.tsx
+++ b/sample/output/app/routes/home/LinkHome.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;

--- a/sample/output/app/routes/home/RedirectHome.tsx
+++ b/sample/output/app/routes/home/RedirectHome.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternHome, {}, props.urlQuery);

--- a/sample/output/app/routes/home/generateUrlHome.ts
+++ b/sample/output/app/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
 const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/app/routes/home/useRedirectHome.ts
+++ b/sample/output/app/routes/home/useRedirectHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectHome = (urlParts: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectHome => {
   const redirect: RedirectHome = (urlParts) => {

--- a/sample/output/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/app/routes/legacy/LinkLegacy.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;

--- a/sample/output/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/app/routes/legacy/RedirectLegacy.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);

--- a/sample/output/app/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/app/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/app/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/app/routes/legacy/useRedirectLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectLegacy => {
   const redirect: RedirectLegacy = (urlParts) => {

--- a/sample/output/app/routes/login/LinkLogin.tsx
+++ b/sample/output/app/routes/login/LinkLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;

--- a/sample/output/app/routes/login/RedirectLogin.tsx
+++ b/sample/output/app/routes/login/RedirectLogin.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);

--- a/sample/output/app/routes/login/generateUrlLogin.ts
+++ b/sample/output/app/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/app/routes/login/useRedirectLogin.ts
+++ b/sample/output/app/routes/login/useRedirectLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectLogin => {
   const redirect: RedirectLogin = (urlParts) => {

--- a/sample/output/app/routes/signup/LinkSignup.tsx
+++ b/sample/output/app/routes/signup/LinkSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;

--- a/sample/output/app/routes/signup/RedirectSignup.tsx
+++ b/sample/output/app/routes/signup/RedirectSignup.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);

--- a/sample/output/app/routes/signup/generateUrlSignup.ts
+++ b/sample/output/app/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/app/routes/signup/useRedirectSignup.ts
+++ b/sample/output/app/routes/signup/useRedirectSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectSignup => {
   const redirect: RedirectSignup = (urlParts) => {

--- a/sample/output/app/routes/toc/LinkToc.tsx
+++ b/sample/output/app/routes/toc/LinkToc.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;

--- a/sample/output/app/routes/toc/RedirectToc.tsx
+++ b/sample/output/app/routes/toc/RedirectToc.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternToc, {}, props.urlQuery);

--- a/sample/output/app/routes/toc/generateUrlToc.ts
+++ b/sample/output/app/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
 const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/app/routes/toc/useRedirectToc.ts
+++ b/sample/output/app/routes/toc/useRedirectToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectToc = (urlParts: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectToc => {
   const redirect: RedirectToc = (urlParts) => {

--- a/sample/output/app/routes/user/LinkUser.tsx
+++ b/sample/output/app/routes/user/LinkUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<LinkProps, "to"> & UrlPartsUser;

--- a/sample/output/app/routes/user/RedirectUser.tsx
+++ b/sample/output/app/routes/user/RedirectUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {

--- a/sample/output/app/routes/user/generateUrlUser.ts
+++ b/sample/output/app/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/app/routes/user/useRedirectUser.ts
+++ b/sample/output/app/routes/user/useRedirectUser.ts
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useHistory } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectUser => {
   const history = useHistory();

--- a/sample/output/auth/routes/about/LinkAbout.tsx
+++ b/sample/output/auth/routes/about/LinkAbout.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;

--- a/sample/output/auth/routes/about/RedirectAbout.tsx
+++ b/sample/output/auth/routes/about/RedirectAbout.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);

--- a/sample/output/auth/routes/about/generateUrlAbout.ts
+++ b/sample/output/auth/routes/about/generateUrlAbout.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/auth/routes/about/useRedirectAbout.ts
+++ b/sample/output/auth/routes/about/useRedirectAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectAbout => {
   const redirect: RedirectAbout = (urlParts) => {

--- a/sample/output/auth/routes/account/LinkAccount.tsx
+++ b/sample/output/auth/routes/account/LinkAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;

--- a/sample/output/auth/routes/account/RedirectAccount.tsx
+++ b/sample/output/auth/routes/account/RedirectAccount.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);

--- a/sample/output/auth/routes/account/generateUrlAccount.ts
+++ b/sample/output/auth/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/auth/routes/account/useRedirectAccount.ts
+++ b/sample/output/auth/routes/account/useRedirectAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectAccount => {
   const redirect: RedirectAccount = (urlParts) => {

--- a/sample/output/auth/routes/home/LinkHome.tsx
+++ b/sample/output/auth/routes/home/LinkHome.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;

--- a/sample/output/auth/routes/home/RedirectHome.tsx
+++ b/sample/output/auth/routes/home/RedirectHome.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternHome, {}, props.urlQuery);

--- a/sample/output/auth/routes/home/generateUrlHome.ts
+++ b/sample/output/auth/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
 const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/auth/routes/home/useRedirectHome.ts
+++ b/sample/output/auth/routes/home/useRedirectHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectHome = (urlParts: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectHome => {
   const redirect: RedirectHome = (urlParts) => {

--- a/sample/output/auth/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/auth/routes/legacy/LinkLegacy.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;

--- a/sample/output/auth/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/auth/routes/legacy/RedirectLegacy.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);

--- a/sample/output/auth/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/auth/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/auth/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/auth/routes/legacy/useRedirectLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectLegacy => {
   const redirect: RedirectLegacy = (urlParts) => {

--- a/sample/output/auth/routes/login/LinkLogin.tsx
+++ b/sample/output/auth/routes/login/LinkLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkLoginProps = Omit<LinkProps, "to"> & UrlPartsLogin;

--- a/sample/output/auth/routes/login/RedirectLogin.tsx
+++ b/sample/output/auth/routes/login/RedirectLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {

--- a/sample/output/auth/routes/login/generateUrlLogin.ts
+++ b/sample/output/auth/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/auth/routes/signup/LinkSignup.tsx
+++ b/sample/output/auth/routes/signup/LinkSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkSignupProps = Omit<LinkProps, "to"> & UrlPartsSignup;

--- a/sample/output/auth/routes/signup/RedirectSignup.tsx
+++ b/sample/output/auth/routes/signup/RedirectSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {

--- a/sample/output/auth/routes/signup/generateUrlSignup.ts
+++ b/sample/output/auth/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/auth/routes/toc/LinkToc.tsx
+++ b/sample/output/auth/routes/toc/LinkToc.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkTocProps = Omit<AnchorProps, "href"> & UrlPartsToc;

--- a/sample/output/auth/routes/toc/RedirectToc.tsx
+++ b/sample/output/auth/routes/toc/RedirectToc.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternToc, {}, props.urlQuery);

--- a/sample/output/auth/routes/toc/generateUrlToc.ts
+++ b/sample/output/auth/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
 const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/auth/routes/toc/useRedirectToc.ts
+++ b/sample/output/auth/routes/toc/useRedirectToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectToc = (urlParts: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectToc => {
   const redirect: RedirectToc = (urlParts) => {

--- a/sample/output/auth/routes/user/LinkUser.tsx
+++ b/sample/output/auth/routes/user/LinkUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;

--- a/sample/output/auth/routes/user/RedirectUser.tsx
+++ b/sample/output/auth/routes/user/RedirectUser.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);

--- a/sample/output/auth/routes/user/generateUrlUser.ts
+++ b/sample/output/auth/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/auth/routes/user/useRedirectUser.ts
+++ b/sample/output/auth/routes/user/useRedirectUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectUser => {
   const redirect: RedirectUser = (urlParts) => {

--- a/sample/output/seo/routes/about/LinkAbout.tsx
+++ b/sample/output/seo/routes/about/LinkAbout.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "next/link";
 import { patternAbout, UrlPartsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<LinkProps, "href"> & UrlPartsAbout;

--- a/sample/output/seo/routes/about/generateUrlAbout.ts
+++ b/sample/output/seo/routes/about/generateUrlAbout.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/seo/routes/account/LinkAccount.tsx
+++ b/sample/output/seo/routes/account/LinkAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;

--- a/sample/output/seo/routes/account/RedirectAccount.tsx
+++ b/sample/output/seo/routes/account/RedirectAccount.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);

--- a/sample/output/seo/routes/account/generateUrlAccount.ts
+++ b/sample/output/seo/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/seo/routes/account/useRedirectAccount.ts
+++ b/sample/output/seo/routes/account/useRedirectAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectAccount => {
   const redirect: RedirectAccount = (urlParts) => {

--- a/sample/output/seo/routes/home/LinkHome.tsx
+++ b/sample/output/seo/routes/home/LinkHome.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "next/link";
 import { patternHome, UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;

--- a/sample/output/seo/routes/home/generateUrlHome.ts
+++ b/sample/output/seo/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
 const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/seo/routes/legacy/LinkLegacy.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;

--- a/sample/output/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/seo/routes/legacy/RedirectLegacy.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);

--- a/sample/output/seo/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/seo/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/seo/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/seo/routes/legacy/useRedirectLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectLegacy => {
   const redirect: RedirectLegacy = (urlParts) => {

--- a/sample/output/seo/routes/login/LinkLogin.tsx
+++ b/sample/output/seo/routes/login/LinkLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;

--- a/sample/output/seo/routes/login/RedirectLogin.tsx
+++ b/sample/output/seo/routes/login/RedirectLogin.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);

--- a/sample/output/seo/routes/login/generateUrlLogin.ts
+++ b/sample/output/seo/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/seo/routes/login/useRedirectLogin.ts
+++ b/sample/output/seo/routes/login/useRedirectLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectLogin => {
   const redirect: RedirectLogin = (urlParts) => {

--- a/sample/output/seo/routes/signup/LinkSignup.tsx
+++ b/sample/output/seo/routes/signup/LinkSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;

--- a/sample/output/seo/routes/signup/RedirectSignup.tsx
+++ b/sample/output/seo/routes/signup/RedirectSignup.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);

--- a/sample/output/seo/routes/signup/generateUrlSignup.ts
+++ b/sample/output/seo/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/seo/routes/signup/useRedirectSignup.ts
+++ b/sample/output/seo/routes/signup/useRedirectSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectSignup => {
   const redirect: RedirectSignup = (urlParts) => {

--- a/sample/output/seo/routes/toc/LinkToc.tsx
+++ b/sample/output/seo/routes/toc/LinkToc.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;

--- a/sample/output/seo/routes/toc/RedirectToc.tsx
+++ b/sample/output/seo/routes/toc/RedirectToc.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternToc, {}, props.urlQuery);

--- a/sample/output/seo/routes/toc/generateUrlToc.ts
+++ b/sample/output/seo/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
 const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/seo/routes/toc/useRedirectToc.ts
+++ b/sample/output/seo/routes/toc/useRedirectToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectToc = (urlParts: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectToc => {
   const redirect: RedirectToc = (urlParts) => {

--- a/sample/output/seo/routes/user/LinkUser.tsx
+++ b/sample/output/seo/routes/user/LinkUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;

--- a/sample/output/seo/routes/user/RedirectUser.tsx
+++ b/sample/output/seo/routes/user/RedirectUser.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);

--- a/sample/output/seo/routes/user/generateUrlUser.ts
+++ b/sample/output/seo/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/seo/routes/user/useRedirectUser.ts
+++ b/sample/output/seo/routes/user/useRedirectUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectUser => {
   const redirect: RedirectUser = (urlParts) => {

--- a/sample/output/server/routes/about/LinkAbout.tsx
+++ b/sample/output/server/routes/about/LinkAbout.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;

--- a/sample/output/server/routes/about/RedirectAbout.tsx
+++ b/sample/output/server/routes/about/RedirectAbout.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);

--- a/sample/output/server/routes/about/generateUrlAbout.ts
+++ b/sample/output/server/routes/about/generateUrlAbout.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/server/routes/about/useRedirectAbout.ts
+++ b/sample/output/server/routes/about/useRedirectAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectAbout => {
   const redirect: RedirectAbout = (urlParts) => {

--- a/sample/output/server/routes/account/LinkAccount.tsx
+++ b/sample/output/server/routes/account/LinkAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;

--- a/sample/output/server/routes/account/RedirectAccount.tsx
+++ b/sample/output/server/routes/account/RedirectAccount.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);

--- a/sample/output/server/routes/account/generateUrlAccount.ts
+++ b/sample/output/server/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/server/routes/account/useRedirectAccount.ts
+++ b/sample/output/server/routes/account/useRedirectAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectAccount => {
   const redirect: RedirectAccount = (urlParts) => {

--- a/sample/output/server/routes/home/LinkHome.tsx
+++ b/sample/output/server/routes/home/LinkHome.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;

--- a/sample/output/server/routes/home/RedirectHome.tsx
+++ b/sample/output/server/routes/home/RedirectHome.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternHome, {}, props.urlQuery);

--- a/sample/output/server/routes/home/generateUrlHome.ts
+++ b/sample/output/server/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
 const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/server/routes/home/useRedirectHome.ts
+++ b/sample/output/server/routes/home/useRedirectHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectHome = (urlParts: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectHome => {
   const redirect: RedirectHome = (urlParts) => {

--- a/sample/output/server/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/server/routes/legacy/LinkLegacy.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;

--- a/sample/output/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/server/routes/legacy/RedirectLegacy.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);

--- a/sample/output/server/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/server/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/server/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/server/routes/legacy/useRedirectLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectLegacy => {
   const redirect: RedirectLegacy = (urlParts) => {

--- a/sample/output/server/routes/login/LinkLogin.tsx
+++ b/sample/output/server/routes/login/LinkLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;

--- a/sample/output/server/routes/login/RedirectLogin.tsx
+++ b/sample/output/server/routes/login/RedirectLogin.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);

--- a/sample/output/server/routes/login/generateUrlLogin.ts
+++ b/sample/output/server/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/server/routes/login/useRedirectLogin.ts
+++ b/sample/output/server/routes/login/useRedirectLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectLogin => {
   const redirect: RedirectLogin = (urlParts) => {

--- a/sample/output/server/routes/signup/LinkSignup.tsx
+++ b/sample/output/server/routes/signup/LinkSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;

--- a/sample/output/server/routes/signup/RedirectSignup.tsx
+++ b/sample/output/server/routes/signup/RedirectSignup.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);

--- a/sample/output/server/routes/signup/generateUrlSignup.ts
+++ b/sample/output/server/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/server/routes/signup/useRedirectSignup.ts
+++ b/sample/output/server/routes/signup/useRedirectSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectSignup => {
   const redirect: RedirectSignup = (urlParts) => {

--- a/sample/output/server/routes/toc/LinkToc.tsx
+++ b/sample/output/server/routes/toc/LinkToc.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;

--- a/sample/output/server/routes/toc/RedirectToc.tsx
+++ b/sample/output/server/routes/toc/RedirectToc.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternToc, {}, props.urlQuery);

--- a/sample/output/server/routes/toc/generateUrlToc.ts
+++ b/sample/output/server/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
 const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/server/routes/toc/useRedirectToc.ts
+++ b/sample/output/server/routes/toc/useRedirectToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectToc = (urlParts: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectToc => {
   const redirect: RedirectToc = (urlParts) => {

--- a/sample/output/server/routes/user/LinkUser.tsx
+++ b/sample/output/server/routes/user/LinkUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;

--- a/sample/output/server/routes/user/RedirectUser.tsx
+++ b/sample/output/server/routes/user/RedirectUser.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);

--- a/sample/output/server/routes/user/generateUrlUser.ts
+++ b/sample/output/server/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/server/routes/user/useRedirectUser.ts
+++ b/sample/output/server/routes/user/useRedirectUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectUser => {
   const redirect: RedirectUser = (urlParts) => {

--- a/sample/output/toc/routes/about/LinkAbout.tsx
+++ b/sample/output/toc/routes/about/LinkAbout.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;

--- a/sample/output/toc/routes/about/RedirectAbout.tsx
+++ b/sample/output/toc/routes/about/RedirectAbout.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAbout, props.path, props.urlQuery);

--- a/sample/output/toc/routes/about/generateUrlAbout.ts
+++ b/sample/output/toc/routes/about/generateUrlAbout.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
 export default generateUrlAbout;

--- a/sample/output/toc/routes/about/useRedirectAbout.ts
+++ b/sample/output/toc/routes/about/useRedirectAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectAbout => {
   const redirect: RedirectAbout = (urlParts) => {

--- a/sample/output/toc/routes/account/LinkAccount.tsx
+++ b/sample/output/toc/routes/account/LinkAccount.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;

--- a/sample/output/toc/routes/account/RedirectAccount.tsx
+++ b/sample/output/toc/routes/account/RedirectAccount.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternAccount, {}, props.urlQuery);

--- a/sample/output/toc/routes/account/generateUrlAccount.ts
+++ b/sample/output/toc/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts.urlQuery);
 export default generateUrlAccount;

--- a/sample/output/toc/routes/account/useRedirectAccount.ts
+++ b/sample/output/toc/routes/account/useRedirectAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectAccount => {
   const redirect: RedirectAccount = (urlParts) => {

--- a/sample/output/toc/routes/home/LinkHome.tsx
+++ b/sample/output/toc/routes/home/LinkHome.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;

--- a/sample/output/toc/routes/home/RedirectHome.tsx
+++ b/sample/output/toc/routes/home/RedirectHome.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternHome, {}, props.urlQuery);

--- a/sample/output/toc/routes/home/generateUrlHome.ts
+++ b/sample/output/toc/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
 const generateUrlHome = (urlParts: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts.urlQuery);
 export default generateUrlHome;

--- a/sample/output/toc/routes/home/useRedirectHome.ts
+++ b/sample/output/toc/routes/home/useRedirectHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectHome = (urlParts: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectHome => {
   const redirect: RedirectHome = (urlParts) => {

--- a/sample/output/toc/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/toc/routes/legacy/LinkLegacy.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;

--- a/sample/output/toc/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/toc/routes/legacy/RedirectLegacy.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLegacy, {}, props.urlQuery);

--- a/sample/output/toc/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/toc/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts.urlQuery);
 export default generateUrlLegacy;

--- a/sample/output/toc/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/toc/routes/legacy/useRedirectLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectLegacy => {
   const redirect: RedirectLegacy = (urlParts) => {

--- a/sample/output/toc/routes/login/LinkLogin.tsx
+++ b/sample/output/toc/routes/login/LinkLogin.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkLoginProps = Omit<AnchorProps, "href"> & UrlPartsLogin;

--- a/sample/output/toc/routes/login/RedirectLogin.tsx
+++ b/sample/output/toc/routes/login/RedirectLogin.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternLogin, {}, props.urlQuery);

--- a/sample/output/toc/routes/login/generateUrlLogin.ts
+++ b/sample/output/toc/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts.urlQuery);
 export default generateUrlLogin;

--- a/sample/output/toc/routes/login/useRedirectLogin.ts
+++ b/sample/output/toc/routes/login/useRedirectLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectLogin => {
   const redirect: RedirectLogin = (urlParts) => {

--- a/sample/output/toc/routes/signup/LinkSignup.tsx
+++ b/sample/output/toc/routes/signup/LinkSignup.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkSignupProps = Omit<AnchorProps, "href"> & UrlPartsSignup;

--- a/sample/output/toc/routes/signup/RedirectSignup.tsx
+++ b/sample/output/toc/routes/signup/RedirectSignup.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternSignup, {}, props.urlQuery);

--- a/sample/output/toc/routes/signup/generateUrlSignup.ts
+++ b/sample/output/toc/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts.urlQuery);
 export default generateUrlSignup;

--- a/sample/output/toc/routes/signup/useRedirectSignup.ts
+++ b/sample/output/toc/routes/signup/useRedirectSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectSignup => {
   const redirect: RedirectSignup = (urlParts) => {

--- a/sample/output/toc/routes/toc/LinkToc.tsx
+++ b/sample/output/toc/routes/toc/LinkToc.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "src/common/components/Link";
 import { patternToc, UrlPartsToc, patternNextJSToc } from "./patternToc";
 type LinkTocProps = Omit<LinkProps, "href"> & UrlPartsToc;

--- a/sample/output/toc/routes/toc/generateUrlToc.ts
+++ b/sample/output/toc/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
 const generateUrlToc = (urlParts: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts.urlQuery);
 export default generateUrlToc;

--- a/sample/output/toc/routes/user/LinkUser.tsx
+++ b/sample/output/toc/routes/user/LinkUser.tsx
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;

--- a/sample/output/toc/routes/user/RedirectUser.tsx
+++ b/sample/output/toc/routes/user/RedirectUser.tsx
@@ -1,7 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import RedirectServerSide from "route-codegen/RedirectServerSide";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
   const to = generateUrl(patternUser, props.path, props.urlQuery);

--- a/sample/output/toc/routes/user/generateUrlUser.ts
+++ b/sample/output/toc/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
 export default generateUrlUser;

--- a/sample/output/toc/routes/user/useRedirectUser.ts
+++ b/sample/output/toc/routes/user/useRedirectUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
-import { generateUrl } from "route-codegen";
+import generateUrl from "route-codegen/generateUrl";
 export type RedirectUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectUser => {
   const redirect: RedirectUser = (urlParts) => {

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -57,7 +57,7 @@ describe("parseAppConfig", () => {
         },
         destinationDir: "path/to/routes",
         routingType: RoutingType.Default,
-        importGenerateUrl: { from: "route-codegen", namedImports: [{ name: "generateUrl" }] },
+        importGenerateUrl: { from: "route-codegen/generateUrl", defaultImport: "generateUrl" },
         importRedirectServerSide: { from: "route-codegen/RedirectServerSide", defaultImport: "RedirectServerSide" },
         routeLinkOptions: {
           ReactRouterV5: { ...defaultParsedLinkOptionsReactRouterV5 },

--- a/src/generate/generateAppFiles/parseAppConfig.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.ts
@@ -63,8 +63,8 @@ interface TopLevelGenerateOptions {
 
 // Note: these imports are constants at the moment but we could open it up so people can pass their own functions in
 const IMPORT_GENERATE_URL: Import = {
-  namedImports: [{ name: "generateUrl" }],
-  from: "route-codegen",
+  defaultImport: "generateUrl",
+  from: "route-codegen/generateUrl",
 };
 const IMPORT_REDIRECT_SERVER_SIDE_COMPONENT: Import = {
   defaultImport: "RedirectServerSide",


### PR DESCRIPTION
## Template

- Import `generateUrl` from `route-codegen/generateUrl` instead of using named import from `route-codegen` to help code splitting