### PR TITLE
Update return type and make it easier to use the callback of useRedirect

### DIFF
--- a/sample/output/app/routes/about/useRedirectAbout.ts
+++ b/sample/output/app/routes/about/useRedirectAbout.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
-const useRedirectAbout = (): RedirectAbout => {
-  const redirect: RedirectAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
+export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
+const useRedirectAbout = (): RedirectFnAbout => {
+  const redirect: RedirectFnAbout = (urlParts) => {
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/account/useRedirectAccount.ts
+++ b/sample/output/app/routes/account/useRedirectAccount.ts
@@ -2,11 +2,11 @@
 import { useHistory } from "react-router";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
-const useRedirectAccount = (): RedirectAccount => {
+export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
+const useRedirectAccount = (): RedirectFnAccount => {
   const history = useHistory();
-  const redirect: RedirectAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts.urlQuery);
+  const redirect: RedirectFnAccount = (urlParts) => {
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
     history.push(to);
   };
   return redirect;

--- a/sample/output/app/routes/home/useRedirectHome.ts
+++ b/sample/output/app/routes/home/useRedirectHome.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectHome = (urlParts: UrlPartsHome) => void;
-const useRedirectHome = (): RedirectHome => {
-  const redirect: RedirectHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts.urlQuery);
+export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
+const useRedirectHome = (): RedirectFnHome => {
+  const redirect: RedirectFnHome = (urlParts) => {
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/app/routes/legacy/useRedirectLegacy.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
-const useRedirectLegacy = (): RedirectLegacy => {
-  const redirect: RedirectLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts.urlQuery);
+export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
+const useRedirectLegacy = (): RedirectFnLegacy => {
+  const redirect: RedirectFnLegacy = (urlParts) => {
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/login/useRedirectLogin.ts
+++ b/sample/output/app/routes/login/useRedirectLogin.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-const useRedirectLogin = (): RedirectLogin => {
-  const redirect: RedirectLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+const useRedirectLogin = (): RedirectFnLogin => {
+  const redirect: RedirectFnLogin = (urlParts) => {
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/signup/useRedirectSignup.ts
+++ b/sample/output/app/routes/signup/useRedirectSignup.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
-const useRedirectSignup = (): RedirectSignup => {
-  const redirect: RedirectSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts.urlQuery);
+export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
+const useRedirectSignup = (): RedirectFnSignup => {
+  const redirect: RedirectFnSignup = (urlParts) => {
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/toc/useRedirectToc.ts
+++ b/sample/output/app/routes/toc/useRedirectToc.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectToc = (urlParts: UrlPartsToc) => void;
-const useRedirectToc = (): RedirectToc => {
-  const redirect: RedirectToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts.urlQuery);
+export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
+const useRedirectToc = (): RedirectFnToc => {
+  const redirect: RedirectFnToc = (urlParts) => {
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/user/useRedirectUser.ts
+++ b/sample/output/app/routes/user/useRedirectUser.ts
@@ -2,11 +2,11 @@
 import { useHistory } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectUser = (urlParts: UrlPartsUser) => void;
-const useRedirectUser = (): RedirectUser => {
+export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
+const useRedirectUser = (): RedirectFnUser => {
   const history = useHistory();
-  const redirect: RedirectUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+  const redirect: RedirectFnUser = (urlParts) => {
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
     history.push(to);
   };
   return redirect;

--- a/sample/output/auth/routes/about/useRedirectAbout.ts
+++ b/sample/output/auth/routes/about/useRedirectAbout.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
-const useRedirectAbout = (): RedirectAbout => {
-  const redirect: RedirectAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
+export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
+const useRedirectAbout = (): RedirectFnAbout => {
+  const redirect: RedirectFnAbout = (urlParts) => {
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/account/useRedirectAccount.ts
+++ b/sample/output/auth/routes/account/useRedirectAccount.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
-const useRedirectAccount = (): RedirectAccount => {
-  const redirect: RedirectAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts.urlQuery);
+export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
+const useRedirectAccount = (): RedirectFnAccount => {
+  const redirect: RedirectFnAccount = (urlParts) => {
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/home/useRedirectHome.ts
+++ b/sample/output/auth/routes/home/useRedirectHome.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectHome = (urlParts: UrlPartsHome) => void;
-const useRedirectHome = (): RedirectHome => {
-  const redirect: RedirectHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts.urlQuery);
+export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
+const useRedirectHome = (): RedirectFnHome => {
+  const redirect: RedirectFnHome = (urlParts) => {
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/auth/routes/legacy/useRedirectLegacy.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
-const useRedirectLegacy = (): RedirectLegacy => {
-  const redirect: RedirectLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts.urlQuery);
+export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
+const useRedirectLegacy = (): RedirectFnLegacy => {
+  const redirect: RedirectFnLegacy = (urlParts) => {
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/toc/useRedirectToc.ts
+++ b/sample/output/auth/routes/toc/useRedirectToc.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectToc = (urlParts: UrlPartsToc) => void;
-const useRedirectToc = (): RedirectToc => {
-  const redirect: RedirectToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts.urlQuery);
+export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
+const useRedirectToc = (): RedirectFnToc => {
+  const redirect: RedirectFnToc = (urlParts) => {
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/user/useRedirectUser.ts
+++ b/sample/output/auth/routes/user/useRedirectUser.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectUser = (urlParts: UrlPartsUser) => void;
-const useRedirectUser = (): RedirectUser => {
-  const redirect: RedirectUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
+const useRedirectUser = (): RedirectFnUser => {
+  const redirect: RedirectFnUser = (urlParts) => {
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/about/useRedirectAbout.ts
+++ b/sample/output/seo/routes/about/useRedirectAbout.ts
@@ -2,10 +2,10 @@
 import Router from "next/router";
 import { patternAbout, UrlPartsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
-const useRedirectAbout = (): RedirectAbout => {
-  const redirect: RedirectAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
+export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
+const useRedirectAbout = (): RedirectFnAbout => {
+  const redirect: RedirectFnAbout = (urlParts) => {
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
     const url = possilePathParamsAbout
       .filter((key) => !(key in urlParts.path))
       .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);

--- a/sample/output/seo/routes/account/useRedirectAccount.ts
+++ b/sample/output/seo/routes/account/useRedirectAccount.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
-const useRedirectAccount = (): RedirectAccount => {
-  const redirect: RedirectAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts.urlQuery);
+export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
+const useRedirectAccount = (): RedirectFnAccount => {
+  const redirect: RedirectFnAccount = (urlParts) => {
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/home/useRedirectHome.ts
+++ b/sample/output/seo/routes/home/useRedirectHome.ts
@@ -2,10 +2,10 @@
 import Router from "next/router";
 import { patternHome, UrlPartsHome, patternNextJSHome } from "./patternHome";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectHome = (urlParts: UrlPartsHome) => void;
-const useRedirectHome = (): RedirectHome => {
-  const redirect: RedirectHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts.urlQuery);
+export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
+const useRedirectHome = (): RedirectFnHome => {
+  const redirect: RedirectFnHome = (urlParts) => {
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
     Router.push(patternNextJSHome, to);
   };
   return redirect;

--- a/sample/output/seo/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/seo/routes/legacy/useRedirectLegacy.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
-const useRedirectLegacy = (): RedirectLegacy => {
-  const redirect: RedirectLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts.urlQuery);
+export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
+const useRedirectLegacy = (): RedirectFnLegacy => {
+  const redirect: RedirectFnLegacy = (urlParts) => {
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/login/useRedirectLogin.ts
+++ b/sample/output/seo/routes/login/useRedirectLogin.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-const useRedirectLogin = (): RedirectLogin => {
-  const redirect: RedirectLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+const useRedirectLogin = (): RedirectFnLogin => {
+  const redirect: RedirectFnLogin = (urlParts) => {
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/signup/useRedirectSignup.ts
+++ b/sample/output/seo/routes/signup/useRedirectSignup.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
-const useRedirectSignup = (): RedirectSignup => {
-  const redirect: RedirectSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts.urlQuery);
+export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
+const useRedirectSignup = (): RedirectFnSignup => {
+  const redirect: RedirectFnSignup = (urlParts) => {
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/toc/useRedirectToc.ts
+++ b/sample/output/seo/routes/toc/useRedirectToc.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectToc = (urlParts: UrlPartsToc) => void;
-const useRedirectToc = (): RedirectToc => {
-  const redirect: RedirectToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts.urlQuery);
+export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
+const useRedirectToc = (): RedirectFnToc => {
+  const redirect: RedirectFnToc = (urlParts) => {
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/user/useRedirectUser.ts
+++ b/sample/output/seo/routes/user/useRedirectUser.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectUser = (urlParts: UrlPartsUser) => void;
-const useRedirectUser = (): RedirectUser => {
-  const redirect: RedirectUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
+const useRedirectUser = (): RedirectFnUser => {
+  const redirect: RedirectFnUser = (urlParts) => {
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/about/useRedirectAbout.ts
+++ b/sample/output/server/routes/about/useRedirectAbout.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
-const useRedirectAbout = (): RedirectAbout => {
-  const redirect: RedirectAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
+export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
+const useRedirectAbout = (): RedirectFnAbout => {
+  const redirect: RedirectFnAbout = (urlParts) => {
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/account/useRedirectAccount.ts
+++ b/sample/output/server/routes/account/useRedirectAccount.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
-const useRedirectAccount = (): RedirectAccount => {
-  const redirect: RedirectAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts.urlQuery);
+export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
+const useRedirectAccount = (): RedirectFnAccount => {
+  const redirect: RedirectFnAccount = (urlParts) => {
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/home/useRedirectHome.ts
+++ b/sample/output/server/routes/home/useRedirectHome.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectHome = (urlParts: UrlPartsHome) => void;
-const useRedirectHome = (): RedirectHome => {
-  const redirect: RedirectHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts.urlQuery);
+export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
+const useRedirectHome = (): RedirectFnHome => {
+  const redirect: RedirectFnHome = (urlParts) => {
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/server/routes/legacy/useRedirectLegacy.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
-const useRedirectLegacy = (): RedirectLegacy => {
-  const redirect: RedirectLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts.urlQuery);
+export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
+const useRedirectLegacy = (): RedirectFnLegacy => {
+  const redirect: RedirectFnLegacy = (urlParts) => {
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/login/useRedirectLogin.ts
+++ b/sample/output/server/routes/login/useRedirectLogin.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-const useRedirectLogin = (): RedirectLogin => {
-  const redirect: RedirectLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+const useRedirectLogin = (): RedirectFnLogin => {
+  const redirect: RedirectFnLogin = (urlParts) => {
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/signup/useRedirectSignup.ts
+++ b/sample/output/server/routes/signup/useRedirectSignup.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
-const useRedirectSignup = (): RedirectSignup => {
-  const redirect: RedirectSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts.urlQuery);
+export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
+const useRedirectSignup = (): RedirectFnSignup => {
+  const redirect: RedirectFnSignup = (urlParts) => {
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/toc/useRedirectToc.ts
+++ b/sample/output/server/routes/toc/useRedirectToc.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsToc, patternToc } from "./patternToc";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectToc = (urlParts: UrlPartsToc) => void;
-const useRedirectToc = (): RedirectToc => {
-  const redirect: RedirectToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts.urlQuery);
+export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
+const useRedirectToc = (): RedirectFnToc => {
+  const redirect: RedirectFnToc = (urlParts) => {
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/user/useRedirectUser.ts
+++ b/sample/output/server/routes/user/useRedirectUser.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectUser = (urlParts: UrlPartsUser) => void;
-const useRedirectUser = (): RedirectUser => {
-  const redirect: RedirectUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
+const useRedirectUser = (): RedirectFnUser => {
+  const redirect: RedirectFnUser = (urlParts) => {
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/about/useRedirectAbout.ts
+++ b/sample/output/toc/routes/about/useRedirectAbout.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAbout = (urlParts: UrlPartsAbout) => void;
-const useRedirectAbout = (): RedirectAbout => {
-  const redirect: RedirectAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts.urlQuery);
+export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
+const useRedirectAbout = (): RedirectFnAbout => {
+  const redirect: RedirectFnAbout = (urlParts) => {
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/account/useRedirectAccount.ts
+++ b/sample/output/toc/routes/account/useRedirectAccount.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectAccount = (urlParts: UrlPartsAccount) => void;
-const useRedirectAccount = (): RedirectAccount => {
-  const redirect: RedirectAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts.urlQuery);
+export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
+const useRedirectAccount = (): RedirectFnAccount => {
+  const redirect: RedirectFnAccount = (urlParts) => {
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/home/useRedirectHome.ts
+++ b/sample/output/toc/routes/home/useRedirectHome.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsHome, patternHome } from "./patternHome";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectHome = (urlParts: UrlPartsHome) => void;
-const useRedirectHome = (): RedirectHome => {
-  const redirect: RedirectHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts.urlQuery);
+export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
+const useRedirectHome = (): RedirectFnHome => {
+  const redirect: RedirectFnHome = (urlParts) => {
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/toc/routes/legacy/useRedirectLegacy.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLegacy = (urlParts: UrlPartsLegacy) => void;
-const useRedirectLegacy = (): RedirectLegacy => {
-  const redirect: RedirectLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts.urlQuery);
+export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
+const useRedirectLegacy = (): RedirectFnLegacy => {
+  const redirect: RedirectFnLegacy = (urlParts) => {
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/login/useRedirectLogin.ts
+++ b/sample/output/toc/routes/login/useRedirectLogin.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-const useRedirectLogin = (): RedirectLogin => {
-  const redirect: RedirectLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+const useRedirectLogin = (): RedirectFnLogin => {
+  const redirect: RedirectFnLogin = (urlParts) => {
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/signup/useRedirectSignup.ts
+++ b/sample/output/toc/routes/signup/useRedirectSignup.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectSignup = (urlParts: UrlPartsSignup) => void;
-const useRedirectSignup = (): RedirectSignup => {
-  const redirect: RedirectSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts.urlQuery);
+export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
+const useRedirectSignup = (): RedirectFnSignup => {
+  const redirect: RedirectFnSignup = (urlParts) => {
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/toc/useRedirectToc.ts
+++ b/sample/output/toc/routes/toc/useRedirectToc.ts
@@ -2,10 +2,10 @@
 import Router from "next/router";
 import { patternToc, UrlPartsToc, patternNextJSToc } from "./patternToc";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectToc = (urlParts: UrlPartsToc) => void;
-const useRedirectToc = (): RedirectToc => {
-  const redirect: RedirectToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts.urlQuery);
+export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
+const useRedirectToc = (): RedirectFnToc => {
+  const redirect: RedirectFnToc = (urlParts) => {
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
     Router.push(patternNextJSToc, to);
   };
   return redirect;

--- a/sample/output/toc/routes/user/useRedirectUser.ts
+++ b/sample/output/toc/routes/user/useRedirectUser.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { UrlPartsUser, patternUser } from "./patternUser";
 import generateUrl from "route-codegen/generateUrl";
-export type RedirectUser = (urlParts: UrlPartsUser) => void;
-const useRedirectUser = (): RedirectUser => {
-  const redirect: RedirectUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts.urlQuery);
+export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
+const useRedirectUser = (): RedirectFnUser => {
+  const redirect: RedirectFnUser = (urlParts) => {
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
@@ -21,10 +21,10 @@ describe("generateUseRedirectFileDefault", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {UrlPartsLogin,patternLogin,} from './patternLogin'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-  const useRedirectLogin = (): RedirectLogin => {
-    const redirect: RedirectLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+  export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+  const useRedirectLogin = (): RedirectFnLogin => {
+    const redirect: RedirectFnLogin = urlParts => {
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
       if (!!window && !!window.location) {
         window.location.href = to;
       }
@@ -56,10 +56,10 @@ describe("generateUseRedirectFileDefault", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {UrlPartsUserInfo,patternUserInfo,} from './patternUserInfo'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectUserInfo = (urlParts: UrlPartsUserInfo) => void;
-  const useRedirectUserInfo = (): RedirectUserInfo => {
-    const redirect: RedirectUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts.urlQuery);
+  export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
+  const useRedirectUserInfo = (): RedirectFnUserInfo => {
+    const redirect: RedirectFnUserInfo = urlParts => {
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
       if (!!window && !!window.location) {
         window.location.href = to;
       }

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
@@ -13,17 +13,19 @@ const generateUseRedirectFileDefault = (params: GenerateUseRedirectFileDefaultPa
   const { routeName, patternNamedExports, destinationDir, importGenerateUrl } = params;
   const functionName = `useRedirect${routeName}`;
   const pathVariable = patternNamedExports.pathParamsInterfaceName ? "urlParts.path" : "{}";
-  const resultTypeInterface = `Redirect${routeName}`;
+  const resultTypeInterface = `RedirectFn${routeName}`;
 
   const template = `${printImport({
     namedImports: [{ name: patternNamedExports.urlPartsInterfaceName }, { name: patternNamedExports.patternName }],
     from: `./${patternNamedExports.filename}`,
   })}
   ${printImport(importGenerateUrl)}
-  export type ${resultTypeInterface} = (urlParts: ${patternNamedExports.urlPartsInterfaceName}) => void;
+  export type ${resultTypeInterface} = (urlParts${!patternNamedExports.pathParamsInterfaceName ? "?" : ""}: ${
+    patternNamedExports.urlPartsInterfaceName
+  }) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts.urlQuery);
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery);
       if (!!window && !!window.location) {
         window.location.href = to;
       }

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
@@ -23,10 +23,10 @@ describe("generateUseRedirectFileNextJS", () => {
     expect(templateFile.template).toContain(`import Router from 'next/router'
   import {patternLogin,UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-  const useRedirectLogin = (): RedirectLogin => {
-    const redirect: RedirectLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+  export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+  const useRedirectLogin = (): RedirectFnLogin => {
+    const redirect: RedirectFnLogin = urlParts => {
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
       Router.push(patternNextJSLogin, to);
     }
     return redirect;
@@ -59,10 +59,10 @@ describe("generateUseRedirectFileNextJS", () => {
     expect(templateFile.template).toContain(`import Router from 'next/router'
   import {patternUserInfo,UrlPartsUserInfo,patternNextJSUserInfo,possiblePathParamsUserInfo,} from './patternUserInfo'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectUserInfo = (urlParts: UrlPartsUserInfo) => void;
-  const useRedirectUserInfo = (): RedirectUserInfo => {
-    const redirect: RedirectUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts.urlQuery);
+  export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
+  const useRedirectUserInfo = (): RedirectFnUserInfo => {
+    const redirect: RedirectFnUserInfo = urlParts => {
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
       const url = possiblePathParamsUserInfo.filter((key) => !(key in urlParts.path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), patternNextJSUserInfo);
       Router.push(url, to);
     }

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
@@ -31,7 +31,7 @@ const generateUseRedirectFileNextJS = (params: GenerateUseRedirectFileNextJSPara
 
   const functionName = `useRedirect${routeName}`;
   const pathVariable = pathParamsInterfaceName ? "urlParts.path" : "{}";
-  const resultTypeInterface = `Redirect${routeName}`;
+  const resultTypeInterface = `RedirectFn${routeName}`;
 
   let namedImportsFromPatternFile = [{ name: patternName }, { name: urlPartsInterfaceName }, { name: patternNameNextJS }];
   let routerTemplate = `Router.push(${patternNameNextJS}, to);`;
@@ -44,10 +44,10 @@ const generateUseRedirectFileNextJS = (params: GenerateUseRedirectFileNextJSPara
   const template = `${printImport({ defaultImport: "Router", from: "next/router" })}
   ${printImport({ namedImports: namedImportsFromPatternFile, from: `./${routePatternFilename}` })}
   ${printImport(importGenerateUrl)}
-  export type ${resultTypeInterface} = (urlParts: ${urlPartsInterfaceName}) => void;
+  export type ${resultTypeInterface} = (urlParts${!pathParamsInterfaceName ? "?" : ""}: ${urlPartsInterfaceName}) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternName}, ${pathVariable}, urlParts.urlQuery);
+      const to = generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery);
       ${routerTemplate}
     }
     return redirect;

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
@@ -22,11 +22,11 @@ describe("generateUseRedirectReactRouterV5", () => {
     expect(templateFile.template).toContain(`import {useHistory,} from 'react-router'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectLogin = (urlParts: UrlPartsLogin) => void;
-  const useRedirectLogin = (): RedirectLogin => {
+  export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
+  const useRedirectLogin = (): RedirectFnLogin => {
     const history = useHistory();
-    const redirect: RedirectLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts.urlQuery);
+    const redirect: RedirectFnLogin = urlParts => {
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
       history.push(to);
     }
     return redirect;
@@ -56,11 +56,11 @@ describe("generateUseRedirectReactRouterV5", () => {
     expect(templateFile.template).toContain(`import {useHistory,} from 'react-router'
   import {UrlPartsUserInfo,patternUserInfo,} from './patternUserInfo'
   import {generateUrl,} from 'route-codegen'
-  export type RedirectUserInfo = (urlParts: UrlPartsUserInfo) => void;
-  const useRedirectUserInfo = (): RedirectUserInfo => {
+  export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
+  const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const history = useHistory();
-    const redirect: RedirectUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts.urlQuery);
+    const redirect: RedirectFnUserInfo = urlParts => {
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
       history.push(to);
     }
     return redirect;

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
@@ -13,7 +13,7 @@ const generateUseRedirectReactRouterV5 = (params: GenerateUseRedirectReactRouter
   const { routeName, patternNamedExports, destinationDir, importGenerateUrl } = params;
   const functionName = `useRedirect${routeName}`;
   const pathVariable = patternNamedExports.pathParamsInterfaceName ? "urlParts.path" : "{}";
-  const resultTypeInterface = `Redirect${routeName}`;
+  const resultTypeInterface = `RedirectFn${routeName}`;
 
   const template = `${printImport({
     namedImports: [{ name: "useHistory" }],
@@ -24,11 +24,13 @@ const generateUseRedirectReactRouterV5 = (params: GenerateUseRedirectReactRouter
     from: `./${patternNamedExports.filename}`,
   })}
   ${printImport(importGenerateUrl)}
-  export type ${resultTypeInterface} = (urlParts: ${patternNamedExports.urlPartsInterfaceName}) => void;
+  export type ${resultTypeInterface} = (urlParts${!patternNamedExports.pathParamsInterfaceName ? "?" : ""}: ${
+    patternNamedExports.urlPartsInterfaceName
+  }) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const history = useHistory();
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts.urlQuery);
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery);
       history.push(to);
     }
     return redirect;


### PR DESCRIPTION
## Template

- Add `Fn` to return type of `useRedirect` to distinguish from the similarly named `Redirect` component
- For `useRedirect` result function, If a route does not require params, make `urlParts` optional 