### PR TITLE
Make path params interface -> type alias

### DIFF
--- a/sample/output/app/routes/about/patternAbout.ts
+++ b/sample/output/app/routes/about/patternAbout.ts
@@ -1,12 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
 
-export interface PathParamsAbout {
-  target: "us" | "you";
-  topic: string;
-  optional?: string;
-  optionalEnum?: "enumOne" | "enumTwo";
-}
+export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {

--- a/sample/output/app/routes/user/patternUser.ts
+++ b/sample/output/app/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 
-export interface PathParamsUser {
-  id: string;
-  subview?: "pictures";
-}
+export type PathParamsUser = { id: string; subview?: "pictures" };
 
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {

--- a/sample/output/auth/routes/about/patternAbout.ts
+++ b/sample/output/auth/routes/about/patternAbout.ts
@@ -1,12 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
 
-export interface PathParamsAbout {
-  target: "us" | "you";
-  topic: string;
-  optional?: string;
-  optionalEnum?: "enumOne" | "enumTwo";
-}
+export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {

--- a/sample/output/auth/routes/user/patternUser.ts
+++ b/sample/output/auth/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 
-export interface PathParamsUser {
-  id: string;
-  subview?: "pictures";
-}
+export type PathParamsUser = { id: string; subview?: "pictures" };
 
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {

--- a/sample/output/seo/routes/about/patternAbout.ts
+++ b/sample/output/seo/routes/about/patternAbout.ts
@@ -1,12 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const patternNextJSAbout = "/about/[target]/[topic]/[optional]/[optionalEnum]";
-export interface PathParamsAbout {
-  target: "us" | "you";
-  topic: string;
-  optional?: string;
-  optionalEnum?: "enumOne" | "enumTwo";
-}
+export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 export interface PathParamsNextJSAbout {
   target: string;
   topic: string;

--- a/sample/output/seo/routes/user/patternUser.ts
+++ b/sample/output/seo/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 
-export interface PathParamsUser {
-  id: string;
-  subview?: "pictures";
-}
+export type PathParamsUser = { id: string; subview?: "pictures" };
 
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {

--- a/sample/output/server/routes/about/patternAbout.ts
+++ b/sample/output/server/routes/about/patternAbout.ts
@@ -1,12 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
 
-export interface PathParamsAbout {
-  target: "us" | "you";
-  topic: string;
-  optional?: string;
-  optionalEnum?: "enumOne" | "enumTwo";
-}
+export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {

--- a/sample/output/server/routes/user/patternUser.ts
+++ b/sample/output/server/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 
-export interface PathParamsUser {
-  id: string;
-  subview?: "pictures";
-}
+export type PathParamsUser = { id: string; subview?: "pictures" };
 
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {

--- a/sample/output/toc/routes/about/patternAbout.ts
+++ b/sample/output/toc/routes/about/patternAbout.ts
@@ -1,12 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
 
-export interface PathParamsAbout {
-  target: "us" | "you";
-  topic: string;
-  optional?: string;
-  optionalEnum?: "enumOne" | "enumTwo";
-}
+export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {

--- a/sample/output/toc/routes/user/patternUser.ts
+++ b/sample/output/toc/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 
-export interface PathParamsUser {
-  id: string;
-  subview?: "pictures";
-}
+export type PathParamsUser = { id: string; subview?: "pictures" };
 
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
@@ -36,7 +36,7 @@ describe("generatePatternFile", () => {
       expect(templateFile.template).toContain(
         `export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
   
-  export interface PathParamsUserInfo {id: string;subview:'profile'|'pictures';}
+  export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
   
   export const possilePathParamsUserInfo = ['id','subview',]
   export interface UrlPartsUserInfo {
@@ -69,7 +69,7 @@ describe("generatePatternFile", () => {
       expect(templateFile.template)
         .toContain(`export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)/:optional?/:optionalEnum(enum1|enum2)?'
   export const patternNextJSUserInfo = '/app/users/[id]/[subview]/[optional]/[optionalEnum]'
-  export interface PathParamsUserInfo {id: string;subview:'profile'|'pictures';optional?: string;optionalEnum?:'enum1'|'enum2';}
+  export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';optional?: string;optionalEnum?:'enum1'|'enum2';}
   export interface PathParamsNextJSUserInfo {id: string;subview: string;optional?: string;optionalEnum?: string;}
   export const possilePathParamsUserInfo = ['id','subview','optional','optionalEnum',]
   export interface UrlPartsUserInfo {

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -67,6 +67,11 @@ const generatePathParamsInterface = (keys: Key[], routeName: string): PathParams
   }
 
   const pathParamsInterfaceName = `PathParams${routeName}`;
+
+  // We need to make this alias type because it's a bit more flexible to use
+  // Using interface for example, creates `Index signature is missing in type` error when using as generic in expressjs RequestHandler
+  // This is because it cannot be used to extend things like `interface A { [key: string]: string; }`
+  // https://github.com/microsoft/TypeScript/issues/15300
   let template = `export type ${pathParamsInterfaceName} = {`;
   keys.forEach((key) => {
     const { pattern, name, modifier } = key;

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -67,7 +67,7 @@ const generatePathParamsInterface = (keys: Key[], routeName: string): PathParams
   }
 
   const pathParamsInterfaceName = `PathParams${routeName}`;
-  let template = `export interface ${pathParamsInterfaceName} {`;
+  let template = `export type ${pathParamsInterfaceName} = {`;
   keys.forEach((key) => {
     const { pattern, name, modifier } = key;
 


### PR DESCRIPTION
Type alias is slightly more flexible to use. In our case, the generated interface cannot be used as the generic of `RequestHandler` of expressjs.

This PR updates this interface to be type alias. Maybe this could be considered as an option instead of forcing it for all templates? 

This is an issue in Typescript https://github.com/microsoft/TypeScript/issues/15300.

