### PR TITLE
Add prefix support

### DIFF
--- a/sample/output/app/routes/about/LinkAbout.tsx
+++ b/sample/output/app/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery);
+const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/app/routes/about/RedirectAbout.tsx
+++ b/sample/output/app/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery);
+  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/app/routes/about/generateUrlAbout.ts
+++ b/sample/output/app/routes/about/generateUrlAbout.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
-const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
+  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAbout;

--- a/sample/output/app/routes/about/patternAbout.ts
+++ b/sample/output/app/routes/about/patternAbout.ts
@@ -7,4 +7,5 @@ export const possilePathParamsAbout = ["target", "topic", "optional", "optionalE
 export interface UrlPartsAbout {
   path: PathParamsAbout;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/about/useRedirectAbout.ts
+++ b/sample/output/app/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/account/LinkAccount.tsx
+++ b/sample/output/app/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<LinkProps, "to"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, urlQuery, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkAccount;

--- a/sample/output/app/routes/account/RedirectAccount.tsx
+++ b/sample/output/app/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery);
+  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/app/routes/account/generateUrlAccount.ts
+++ b/sample/output/app/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
-const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery);
+const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAccount;

--- a/sample/output/app/routes/account/patternAccount.ts
+++ b/sample/output/app/routes/account/patternAccount.ts
@@ -3,4 +3,5 @@ export const patternAccount = "/app/account";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/account/useRedirectAccount.ts
+++ b/sample/output/app/routes/account/useRedirectAccount.ts
@@ -6,7 +6,7 @@ export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const history = useHistory();
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
     history.push(to);
   };
   return redirect;

--- a/sample/output/app/routes/home/LinkHome.tsx
+++ b/sample/output/app/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/app/routes/home/RedirectHome.tsx
+++ b/sample/output/app/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery);
+  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/app/routes/home/generateUrlHome.ts
+++ b/sample/output/app/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlHome;

--- a/sample/output/app/routes/home/patternHome.ts
+++ b/sample/output/app/routes/home/patternHome.ts
@@ -3,4 +3,5 @@ export const patternHome = "/";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/home/useRedirectHome.ts
+++ b/sample/output/app/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/app/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/app/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery);
+  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/app/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/app/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
-const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLegacy;

--- a/sample/output/app/routes/legacy/patternLegacy.ts
+++ b/sample/output/app/routes/legacy/patternLegacy.ts
@@ -3,4 +3,5 @@ export const patternLegacy = "/legacy/app";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/app/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/login/LinkLogin.tsx
+++ b/sample/output/app/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/app/routes/login/RedirectLogin.tsx
+++ b/sample/output/app/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery);
+  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/app/routes/login/generateUrlLogin.ts
+++ b/sample/output/app/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
-const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery);
+const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLogin;

--- a/sample/output/app/routes/login/patternLogin.ts
+++ b/sample/output/app/routes/login/patternLogin.ts
@@ -3,4 +3,5 @@ export const patternLogin = "/login";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/login/useRedirectLogin.ts
+++ b/sample/output/app/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/signup/LinkSignup.tsx
+++ b/sample/output/app/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/app/routes/signup/RedirectSignup.tsx
+++ b/sample/output/app/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery);
+  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/app/routes/signup/generateUrlSignup.ts
+++ b/sample/output/app/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
-const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery);
+const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlSignup;

--- a/sample/output/app/routes/signup/patternSignup.ts
+++ b/sample/output/app/routes/signup/patternSignup.ts
@@ -3,4 +3,5 @@ export const patternSignup = "/signup";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/signup/useRedirectSignup.ts
+++ b/sample/output/app/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/toc/LinkToc.tsx
+++ b/sample/output/app/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/app/routes/toc/RedirectToc.tsx
+++ b/sample/output/app/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery);
+  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/app/routes/toc/generateUrlToc.ts
+++ b/sample/output/app/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlToc;

--- a/sample/output/app/routes/toc/patternToc.ts
+++ b/sample/output/app/routes/toc/patternToc.ts
@@ -3,4 +3,5 @@ export const patternToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/toc/useRedirectToc.ts
+++ b/sample/output/app/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/user/LinkUser.tsx
+++ b/sample/output/app/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<LinkProps, "to"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, urlQuery, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkUser;

--- a/sample/output/app/routes/user/RedirectUser.tsx
+++ b/sample/output/app/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery);
+  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/app/routes/user/generateUrlUser.ts
+++ b/sample/output/app/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
-const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlUser;

--- a/sample/output/app/routes/user/patternUser.ts
+++ b/sample/output/app/routes/user/patternUser.ts
@@ -7,4 +7,5 @@ export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/app/routes/user/useRedirectUser.ts
+++ b/sample/output/app/routes/user/useRedirectUser.ts
@@ -6,7 +6,7 @@ export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const history = useHistory();
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     history.push(to);
   };
   return redirect;

--- a/sample/output/auth/routes/about/LinkAbout.tsx
+++ b/sample/output/auth/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery);
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/auth/routes/about/RedirectAbout.tsx
+++ b/sample/output/auth/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery);
+  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/auth/routes/about/generateUrlAbout.ts
+++ b/sample/output/auth/routes/about/generateUrlAbout.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
-const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
+  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAbout;

--- a/sample/output/auth/routes/about/patternAbout.ts
+++ b/sample/output/auth/routes/about/patternAbout.ts
@@ -7,4 +7,5 @@ export const possilePathParamsAbout = ["target", "topic", "optional", "optionalE
 export interface UrlPartsAbout {
   path: PathParamsAbout;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/about/useRedirectAbout.ts
+++ b/sample/output/auth/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/account/LinkAccount.tsx
+++ b/sample/output/auth/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/auth/routes/account/RedirectAccount.tsx
+++ b/sample/output/auth/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery);
+  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/auth/routes/account/generateUrlAccount.ts
+++ b/sample/output/auth/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
-const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery);
+const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAccount;

--- a/sample/output/auth/routes/account/patternAccount.ts
+++ b/sample/output/auth/routes/account/patternAccount.ts
@@ -3,4 +3,5 @@ export const patternAccount = "/app/account";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/account/useRedirectAccount.ts
+++ b/sample/output/auth/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/home/LinkHome.tsx
+++ b/sample/output/auth/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery);
+const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/auth/routes/home/RedirectHome.tsx
+++ b/sample/output/auth/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery);
+  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/auth/routes/home/generateUrlHome.ts
+++ b/sample/output/auth/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlHome;

--- a/sample/output/auth/routes/home/patternHome.ts
+++ b/sample/output/auth/routes/home/patternHome.ts
@@ -3,4 +3,5 @@ export const patternHome = "/";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/home/useRedirectHome.ts
+++ b/sample/output/auth/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/auth/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery);
+const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/auth/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/auth/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery);
+  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/auth/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/auth/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
-const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLegacy;

--- a/sample/output/auth/routes/legacy/patternLegacy.ts
+++ b/sample/output/auth/routes/legacy/patternLegacy.ts
@@ -3,4 +3,5 @@ export const patternLegacy = "/legacy/app";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/auth/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/login/LinkLogin.tsx
+++ b/sample/output/auth/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkLoginProps = Omit<LinkProps, "to"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery);
+const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, urlQuery, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkLogin;

--- a/sample/output/auth/routes/login/RedirectLogin.tsx
+++ b/sample/output/auth/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery);
+  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/auth/routes/login/generateUrlLogin.ts
+++ b/sample/output/auth/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
-const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery);
+const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLogin;

--- a/sample/output/auth/routes/login/patternLogin.ts
+++ b/sample/output/auth/routes/login/patternLogin.ts
@@ -3,4 +3,5 @@ export const patternLogin = "/login";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/signup/LinkSignup.tsx
+++ b/sample/output/auth/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkSignupProps = Omit<LinkProps, "to"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery);
+const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, urlQuery, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkSignup;

--- a/sample/output/auth/routes/signup/RedirectSignup.tsx
+++ b/sample/output/auth/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery);
+  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/auth/routes/signup/generateUrlSignup.ts
+++ b/sample/output/auth/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
-const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery);
+const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlSignup;

--- a/sample/output/auth/routes/signup/patternSignup.ts
+++ b/sample/output/auth/routes/signup/patternSignup.ts
@@ -3,4 +3,5 @@ export const patternSignup = "/signup";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/toc/LinkToc.tsx
+++ b/sample/output/auth/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkTocProps = Omit<AnchorProps, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery);
+const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/auth/routes/toc/RedirectToc.tsx
+++ b/sample/output/auth/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery);
+  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/auth/routes/toc/generateUrlToc.ts
+++ b/sample/output/auth/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlToc;

--- a/sample/output/auth/routes/toc/patternToc.ts
+++ b/sample/output/auth/routes/toc/patternToc.ts
@@ -3,4 +3,5 @@ export const patternToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/toc/useRedirectToc.ts
+++ b/sample/output/auth/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/user/LinkUser.tsx
+++ b/sample/output/auth/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/auth/routes/user/RedirectUser.tsx
+++ b/sample/output/auth/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery);
+  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/auth/routes/user/generateUrlUser.ts
+++ b/sample/output/auth/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
-const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlUser;

--- a/sample/output/auth/routes/user/patternUser.ts
+++ b/sample/output/auth/routes/user/patternUser.ts
@@ -7,4 +7,5 @@ export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/auth/routes/user/useRedirectUser.ts
+++ b/sample/output/auth/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/about/LinkAbout.tsx
+++ b/sample/output/seo/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "next/link";
 import { patternAbout, UrlPartsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<LinkProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery);
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, urlQuery, origin);
   const href = possilePathParamsAbout
     .filter((key) => !(key in path))
     .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);

--- a/sample/output/seo/routes/about/generateUrlAbout.ts
+++ b/sample/output/seo/routes/about/generateUrlAbout.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
-const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
+  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAbout;

--- a/sample/output/seo/routes/about/patternAbout.ts
+++ b/sample/output/seo/routes/about/patternAbout.ts
@@ -12,4 +12,5 @@ export const possilePathParamsAbout = ["target", "topic", "optional", "optionalE
 export interface UrlPartsAbout {
   path: PathParamsAbout;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/about/useRedirectAbout.ts
+++ b/sample/output/seo/routes/about/useRedirectAbout.ts
@@ -5,7 +5,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     const url = possilePathParamsAbout
       .filter((key) => !(key in urlParts.path))
       .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);

--- a/sample/output/seo/routes/account/LinkAccount.tsx
+++ b/sample/output/seo/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery);
+const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/seo/routes/account/RedirectAccount.tsx
+++ b/sample/output/seo/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery);
+  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/seo/routes/account/generateUrlAccount.ts
+++ b/sample/output/seo/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
-const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery);
+const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAccount;

--- a/sample/output/seo/routes/account/patternAccount.ts
+++ b/sample/output/seo/routes/account/patternAccount.ts
@@ -3,4 +3,5 @@ export const patternAccount = "/app/account";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/account/useRedirectAccount.ts
+++ b/sample/output/seo/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/home/LinkHome.tsx
+++ b/sample/output/seo/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "next/link";
 import { patternHome, UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery);
+const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, urlQuery, origin);
   return <Link {...props} href={patternNextJSHome} as={to} />;
 };
 export default LinkHome;

--- a/sample/output/seo/routes/home/generateUrlHome.ts
+++ b/sample/output/seo/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlHome;

--- a/sample/output/seo/routes/home/patternHome.ts
+++ b/sample/output/seo/routes/home/patternHome.ts
@@ -4,4 +4,5 @@ export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/home/useRedirectHome.ts
+++ b/sample/output/seo/routes/home/useRedirectHome.ts
@@ -5,7 +5,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
     Router.push(patternNextJSHome, to);
   };
   return redirect;

--- a/sample/output/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/seo/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/seo/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery);
+  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/seo/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/seo/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
-const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLegacy;

--- a/sample/output/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output/seo/routes/legacy/patternLegacy.ts
@@ -3,4 +3,5 @@ export const patternLegacy = "/legacy/app";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/seo/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/login/LinkLogin.tsx
+++ b/sample/output/seo/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/seo/routes/login/RedirectLogin.tsx
+++ b/sample/output/seo/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery);
+  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/seo/routes/login/generateUrlLogin.ts
+++ b/sample/output/seo/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
-const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery);
+const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLogin;

--- a/sample/output/seo/routes/login/patternLogin.ts
+++ b/sample/output/seo/routes/login/patternLogin.ts
@@ -3,4 +3,5 @@ export const patternLogin = "/login";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/login/useRedirectLogin.ts
+++ b/sample/output/seo/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/signup/LinkSignup.tsx
+++ b/sample/output/seo/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/seo/routes/signup/RedirectSignup.tsx
+++ b/sample/output/seo/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery);
+  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/seo/routes/signup/generateUrlSignup.ts
+++ b/sample/output/seo/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
-const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery);
+const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlSignup;

--- a/sample/output/seo/routes/signup/patternSignup.ts
+++ b/sample/output/seo/routes/signup/patternSignup.ts
@@ -3,4 +3,5 @@ export const patternSignup = "/signup";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/signup/useRedirectSignup.ts
+++ b/sample/output/seo/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/toc/LinkToc.tsx
+++ b/sample/output/seo/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/seo/routes/toc/RedirectToc.tsx
+++ b/sample/output/seo/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery);
+  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/seo/routes/toc/generateUrlToc.ts
+++ b/sample/output/seo/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlToc;

--- a/sample/output/seo/routes/toc/patternToc.ts
+++ b/sample/output/seo/routes/toc/patternToc.ts
@@ -3,4 +3,5 @@ export const patternToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/toc/useRedirectToc.ts
+++ b/sample/output/seo/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/user/LinkUser.tsx
+++ b/sample/output/seo/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/seo/routes/user/RedirectUser.tsx
+++ b/sample/output/seo/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery);
+  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/seo/routes/user/generateUrlUser.ts
+++ b/sample/output/seo/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
-const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlUser;

--- a/sample/output/seo/routes/user/patternUser.ts
+++ b/sample/output/seo/routes/user/patternUser.ts
@@ -7,4 +7,5 @@ export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/seo/routes/user/useRedirectUser.ts
+++ b/sample/output/seo/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/about/LinkAbout.tsx
+++ b/sample/output/server/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery);
+const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/server/routes/about/RedirectAbout.tsx
+++ b/sample/output/server/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery);
+  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/server/routes/about/generateUrlAbout.ts
+++ b/sample/output/server/routes/about/generateUrlAbout.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
-const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
+  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAbout;

--- a/sample/output/server/routes/about/patternAbout.ts
+++ b/sample/output/server/routes/about/patternAbout.ts
@@ -7,4 +7,5 @@ export const possilePathParamsAbout = ["target", "topic", "optional", "optionalE
 export interface UrlPartsAbout {
   path: PathParamsAbout;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/about/useRedirectAbout.ts
+++ b/sample/output/server/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/account/LinkAccount.tsx
+++ b/sample/output/server/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery);
+const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/server/routes/account/RedirectAccount.tsx
+++ b/sample/output/server/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery);
+  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/server/routes/account/generateUrlAccount.ts
+++ b/sample/output/server/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
-const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery);
+const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAccount;

--- a/sample/output/server/routes/account/patternAccount.ts
+++ b/sample/output/server/routes/account/patternAccount.ts
@@ -3,4 +3,5 @@ export const patternAccount = "/app/account";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/account/useRedirectAccount.ts
+++ b/sample/output/server/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/home/LinkHome.tsx
+++ b/sample/output/server/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/server/routes/home/RedirectHome.tsx
+++ b/sample/output/server/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery);
+  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/server/routes/home/generateUrlHome.ts
+++ b/sample/output/server/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlHome;

--- a/sample/output/server/routes/home/patternHome.ts
+++ b/sample/output/server/routes/home/patternHome.ts
@@ -3,4 +3,5 @@ export const patternHome = "/";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/home/useRedirectHome.ts
+++ b/sample/output/server/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/server/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/server/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery);
+  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/server/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/server/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
-const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLegacy;

--- a/sample/output/server/routes/legacy/patternLegacy.ts
+++ b/sample/output/server/routes/legacy/patternLegacy.ts
@@ -3,4 +3,5 @@ export const patternLegacy = "/legacy/app";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/server/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/login/LinkLogin.tsx
+++ b/sample/output/server/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/server/routes/login/RedirectLogin.tsx
+++ b/sample/output/server/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery);
+  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/server/routes/login/generateUrlLogin.ts
+++ b/sample/output/server/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
-const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery);
+const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLogin;

--- a/sample/output/server/routes/login/patternLogin.ts
+++ b/sample/output/server/routes/login/patternLogin.ts
@@ -3,4 +3,5 @@ export const patternLogin = "/login";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/login/useRedirectLogin.ts
+++ b/sample/output/server/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/signup/LinkSignup.tsx
+++ b/sample/output/server/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/server/routes/signup/RedirectSignup.tsx
+++ b/sample/output/server/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery);
+  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/server/routes/signup/generateUrlSignup.ts
+++ b/sample/output/server/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
-const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery);
+const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlSignup;

--- a/sample/output/server/routes/signup/patternSignup.ts
+++ b/sample/output/server/routes/signup/patternSignup.ts
@@ -3,4 +3,5 @@ export const patternSignup = "/signup";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/signup/useRedirectSignup.ts
+++ b/sample/output/server/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/toc/LinkToc.tsx
+++ b/sample/output/server/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/server/routes/toc/RedirectToc.tsx
+++ b/sample/output/server/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery);
+  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/server/routes/toc/generateUrlToc.ts
+++ b/sample/output/server/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlToc;

--- a/sample/output/server/routes/toc/patternToc.ts
+++ b/sample/output/server/routes/toc/patternToc.ts
@@ -3,4 +3,5 @@ export const patternToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/toc/useRedirectToc.ts
+++ b/sample/output/server/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/user/LinkUser.tsx
+++ b/sample/output/server/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, urlQuery, origin);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/server/routes/user/RedirectUser.tsx
+++ b/sample/output/server/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery);
+  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/server/routes/user/generateUrlUser.ts
+++ b/sample/output/server/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
-const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlUser;

--- a/sample/output/server/routes/user/patternUser.ts
+++ b/sample/output/server/routes/user/patternUser.ts
@@ -7,4 +7,5 @@ export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/server/routes/user/useRedirectUser.ts
+++ b/sample/output/server/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/about/LinkAbout.tsx
+++ b/sample/output/toc/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery);
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/toc/routes/about/RedirectAbout.tsx
+++ b/sample/output/toc/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery);
+  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/toc/routes/about/generateUrlAbout.ts
+++ b/sample/output/toc/routes/about/generateUrlAbout.ts
@@ -1,5 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout } from "./patternAbout";
-const generateUrlAbout = (urlParts: UrlPartsAbout): string => generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
+  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAbout;

--- a/sample/output/toc/routes/about/patternAbout.ts
+++ b/sample/output/toc/routes/about/patternAbout.ts
@@ -7,4 +7,5 @@ export const possilePathParamsAbout = ["target", "topic", "optional", "optionalE
 export interface UrlPartsAbout {
   path: PathParamsAbout;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/about/useRedirectAbout.ts
+++ b/sample/output/toc/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/account/LinkAccount.tsx
+++ b/sample/output/toc/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/toc/routes/account/RedirectAccount.tsx
+++ b/sample/output/toc/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery);
+  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/toc/routes/account/generateUrlAccount.ts
+++ b/sample/output/toc/routes/account/generateUrlAccount.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
-const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery);
+const generateUrlAccount = (urlParts?: UrlPartsAccount): string => generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlAccount;

--- a/sample/output/toc/routes/account/patternAccount.ts
+++ b/sample/output/toc/routes/account/patternAccount.ts
@@ -3,4 +3,5 @@ export const patternAccount = "/app/account";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/account/useRedirectAccount.ts
+++ b/sample/output/toc/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/home/LinkHome.tsx
+++ b/sample/output/toc/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternHome, UrlPartsHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery);
+const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/toc/routes/home/RedirectHome.tsx
+++ b/sample/output/toc/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery);
+  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/toc/routes/home/generateUrlHome.ts
+++ b/sample/output/toc/routes/home/generateUrlHome.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlHome;

--- a/sample/output/toc/routes/home/patternHome.ts
+++ b/sample/output/toc/routes/home/patternHome.ts
@@ -3,4 +3,5 @@ export const patternHome = "/";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/home/useRedirectHome.ts
+++ b/sample/output/toc/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/toc/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery);
+const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/toc/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/toc/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery);
+  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/toc/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/toc/routes/legacy/generateUrlLegacy.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy } from "./patternLegacy";
-const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string => generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLegacy;

--- a/sample/output/toc/routes/legacy/patternLegacy.ts
+++ b/sample/output/toc/routes/legacy/patternLegacy.ts
@@ -3,4 +3,5 @@ export const patternLegacy = "/legacy/app";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/toc/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/login/LinkLogin.tsx
+++ b/sample/output/toc/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkLoginProps = Omit<AnchorProps, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery);
+const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/toc/routes/login/RedirectLogin.tsx
+++ b/sample/output/toc/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery);
+  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/toc/routes/login/generateUrlLogin.ts
+++ b/sample/output/toc/routes/login/generateUrlLogin.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
-const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery);
+const generateUrlLogin = (urlParts?: UrlPartsLogin): string => generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlLogin;

--- a/sample/output/toc/routes/login/patternLogin.ts
+++ b/sample/output/toc/routes/login/patternLogin.ts
@@ -3,4 +3,5 @@ export const patternLogin = "/login";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/login/useRedirectLogin.ts
+++ b/sample/output/toc/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/signup/LinkSignup.tsx
+++ b/sample/output/toc/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkSignupProps = Omit<AnchorProps, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery);
+const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/toc/routes/signup/RedirectSignup.tsx
+++ b/sample/output/toc/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery);
+  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/toc/routes/signup/generateUrlSignup.ts
+++ b/sample/output/toc/routes/signup/generateUrlSignup.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
-const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery);
+const generateUrlSignup = (urlParts?: UrlPartsSignup): string => generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlSignup;

--- a/sample/output/toc/routes/signup/patternSignup.ts
+++ b/sample/output/toc/routes/signup/patternSignup.ts
@@ -3,4 +3,5 @@ export const patternSignup = "/signup";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/signup/useRedirectSignup.ts
+++ b/sample/output/toc/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/toc/LinkToc.tsx
+++ b/sample/output/toc/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "src/common/components/Link";
 import { patternToc, UrlPartsToc, patternNextJSToc } from "./patternToc";
 type LinkTocProps = Omit<LinkProps, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery);
+const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, urlQuery, origin);
   return <Link {...props} href={patternNextJSToc} as={to} />;
 };
 export default LinkToc;

--- a/sample/output/toc/routes/toc/generateUrlToc.ts
+++ b/sample/output/toc/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlToc;

--- a/sample/output/toc/routes/toc/patternToc.ts
+++ b/sample/output/toc/routes/toc/patternToc.ts
@@ -4,4 +4,5 @@ export const patternNextJSToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/toc/useRedirectToc.ts
+++ b/sample/output/toc/routes/toc/useRedirectToc.ts
@@ -5,7 +5,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery);
+    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin);
     Router.push(patternNextJSToc, to);
   };
   return redirect;

--- a/sample/output/toc/routes/user/LinkUser.tsx
+++ b/sample/output/toc/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, urlQuery, origin);
   return <Link {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/toc/routes/user/RedirectUser.tsx
+++ b/sample/output/toc/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery);
+  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/toc/routes/user/generateUrlUser.ts
+++ b/sample/output/toc/routes/user/generateUrlUser.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser } from "./patternUser";
-const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+const generateUrlUser = (urlParts: UrlPartsUser): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
 export default generateUrlUser;

--- a/sample/output/toc/routes/user/patternUser.ts
+++ b/sample/output/toc/routes/user/patternUser.ts
@@ -7,4 +7,5 @@ export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
   urlQuery?: Record<string, string>;
+  origin?: string;
 }

--- a/sample/output/toc/routes/user/useRedirectUser.ts
+++ b/sample/output/toc/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
@@ -42,6 +42,7 @@ describe("generatePatternFile", () => {
   export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
     urlQuery?: Record<string, string>;
+    origin?: string;
   }`
       );
       expect(interfaceResult).toEqual({
@@ -75,6 +76,7 @@ describe("generatePatternFile", () => {
   export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
     urlQuery?: Record<string, string>;
+    origin?: string;
   }`);
       expect(interfaceResult).toEqual({
         patternName: "patternUserInfo",

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -155,6 +155,7 @@ const generateUrlPartsInterface = (
   const template = `export interface ${interfaceName} {
     ${pathParams ? `path: ${pathParams.interfaceName};` : ""}
     urlQuery?: Record<string, string>;
+    origin?: string;
   }`;
 
   return { template, interfaceName };

--- a/src/generate/generateAppFiles/generatorCore/generateUrlFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generateUrlFile.test.ts
@@ -18,7 +18,7 @@ describe("generateUseParamsFile", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,} from './patternUser'
-  const generateUrlUser = ( urlParts?: UrlPartsUser ): string => generateUrl(patternUser, {}, urlParts?.urlQuery);
+  const generateUrlUser = ( urlParts?: UrlPartsUser ): string => generateUrl(patternUser, {}, urlParts?.urlQuery, urlParts?.origin);
   export default generateUrlUser;`);
   });
 
@@ -40,7 +40,7 @@ describe("generateUseParamsFile", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,} from './patternUser'
-  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery);
+  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
   export default generateUrlUser;`);
   });
 });

--- a/src/generate/generateAppFiles/generatorCore/generateUrlFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generateUrlFile.ts
@@ -24,7 +24,7 @@ const generateUrlFile: GenerateUrlFile = ({
     namedImports: [{ name: patternName }, { name: urlPartsInterfaceName }],
     from: `./${filename}`,
   })}
-  const ${functionName} = ( urlParts${urlPartOptionalModifier}: ${urlPartsInterfaceName} ): string => generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery);
+  const ${functionName} = ( urlParts${urlPartOptionalModifier}: ${urlPartsInterfaceName} ): string => generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin);
   export default ${functionName};
   `;
 

--- a/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
@@ -51,8 +51,8 @@ describe("generateLinkFileDefault", () => {
   import Link, {CustomLinkProps,} from 'src/Default/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} customDefaultHref={to} />;
   }
   export default LinkLogin;`);
@@ -69,8 +69,8 @@ describe("generateLinkFileDefault", () => {
   
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <a {...props} href={to} />;
   }
   export default LinkLogin;`);
@@ -93,8 +93,8 @@ describe("generateLinkFileDefault", () => {
   
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, path, urlQuery);
+  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, path, urlQuery, origin);
     return <a {...props} href={to} />;
   }
   export default LinkLogin;`);
@@ -125,8 +125,8 @@ describe("generateLinkFileDefault", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);

--- a/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
@@ -38,8 +38,10 @@ const generateLinkFileDefault = (params: GenerateLinkFileDefaultParams): Templat
     from: `./${routePatternFilename}`,
   })}
   ${linkPropsTemplate}
-  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${hasPathParams ? "path," : ""} urlQuery, ...props }) => {
-    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery);
+  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
+    hasPathParams ? "path," : ""
+  } urlQuery, origin, ...props }) => {
+    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery, origin);
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }
   export default ${functionName};

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
@@ -25,7 +25,7 @@ describe("generateRedirectFileDefault", () => {
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, {}, props.urlQuery);
+    const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
     return <RedirectServerSide href={to} fallback={props.fallback} />;
   };
   export default RedirectLogin`);
@@ -48,7 +48,7 @@ describe("generateRedirectFileDefault", () => {
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, props.path, props.urlQuery);
+    const to = generateUrl(patternLogin, props.path, props.urlQuery, props.origin);
     return <RedirectServerSide href={to} fallback={props.fallback} />;
   };
   export default RedirectLogin`);

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
@@ -24,7 +24,7 @@ const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultParams):
     from: `./${patternNamedExports.filename}`,
   })}
   const ${functionName}: React.FunctionComponent<${patternNamedExports.urlPartsInterfaceName} & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery);
+    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery, props.origin);
     return <${importRedirectServerSide.defaultImport} href={to} fallback={props.fallback} />;
   };
   export default ${functionName}`;

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
@@ -24,7 +24,7 @@ describe("generateUseRedirectFileDefault", () => {
   export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
   const useRedirectLogin = (): RedirectFnLogin => {
     const redirect: RedirectFnLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
       if (!!window && !!window.location) {
         window.location.href = to;
       }
@@ -59,7 +59,7 @@ describe("generateUseRedirectFileDefault", () => {
   export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const redirect: RedirectFnUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
       if (!!window && !!window.location) {
         window.location.href = to;
       }

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
@@ -25,7 +25,7 @@ const generateUseRedirectFileDefault = (params: GenerateUseRedirectFileDefaultPa
   }) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery);
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin);
       if (!!window && !!window.location) {
         window.location.href = to;
       }

--- a/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
@@ -38,8 +38,8 @@ describe("generateLinkFileNextJS", () => {
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
   import {patternLogin,UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} customHref={patternNextJSLogin} as={to} />;
   }
   export default LinkLogin;`);
@@ -63,8 +63,8 @@ describe("generateLinkFileNextJS", () => {
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
   import {patternLogin,UrlPartsLogin,patternNextJSLogin,possiblePathParamsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, path, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, path, urlQuery, origin);
     const href = possiblePathParamsLogin.filter((key) => !(key in path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), patternNextJSLogin);
     return <Link {...props} customHref={href} as={to} />;
   }
@@ -96,8 +96,8 @@ describe("generateLinkFileNextJS", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} to={patternNextJSLogin} as={to} />;
   }
   export default LinkLogin;`);

--- a/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.ts
@@ -60,8 +60,10 @@ const generateLinkFileNextJS = (params: GenerateLinkFileNextJSParams): TemplateF
     from: `./${routePatternFilename}`,
   })}
   ${linkPropsTemplate}
-  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${hasPathParams ? "path," : ""} urlQuery, ...props }) => {
-    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery);
+  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
+    hasPathParams ? "path," : ""
+  } urlQuery, origin, ...props }) => {
+    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery, origin);
     ${linkTemplate}
   }
   export default ${functionName};

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
@@ -26,7 +26,7 @@ describe("generateUseRedirectFileNextJS", () => {
   export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
   const useRedirectLogin = (): RedirectFnLogin => {
     const redirect: RedirectFnLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
       Router.push(patternNextJSLogin, to);
     }
     return redirect;
@@ -62,7 +62,7 @@ describe("generateUseRedirectFileNextJS", () => {
   export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const redirect: RedirectFnUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
       const url = possiblePathParamsUserInfo.filter((key) => !(key in urlParts.path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), patternNextJSUserInfo);
       Router.push(url, to);
     }

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
@@ -47,7 +47,7 @@ const generateUseRedirectFileNextJS = (params: GenerateUseRedirectFileNextJSPara
   export type ${resultTypeInterface} = (urlParts${!pathParamsInterfaceName ? "?" : ""}: ${urlPartsInterfaceName}) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery);
+      const to = generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin);
       ${routerTemplate}
     }
     return redirect;

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
@@ -39,8 +39,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import Link, {CustomLinkProps,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);
@@ -63,8 +63,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import Link, {CustomLinkProps,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, path, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, path, urlQuery, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);
@@ -96,8 +96,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, urlQuery, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
@@ -38,8 +38,10 @@ const generateLinkFileReactRouterV5 = (params: GenerateLinkFileReactRouterV5Para
     from: `./${routePatternFilename}`,
   })}
   ${linkPropsTemplate}
-  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${hasPathParams ? "path," : ""} urlQuery, ...props }) => {
-    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery);
+  const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
+    hasPathParams ? "path," : ""
+  } urlQuery, origin, ...props }) => {
+    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery, origin);
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }
   export default ${functionName};

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
@@ -24,7 +24,7 @@ describe("generateRedirectFileReactRouterV5", () => {
   import {Redirect,} from 'react-router'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, {}, props.urlQuery);
+    const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
     return (
       <>
         <Redirect to={to} />
@@ -52,7 +52,7 @@ describe("generateRedirectFileReactRouterV5", () => {
   import {Redirect,} from 'react-router'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, props.path, props.urlQuery);
+    const to = generateUrl(patternLogin, props.path, props.urlQuery, props.origin);
     return (
       <>
         <Redirect to={to} />

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
@@ -23,7 +23,7 @@ const generateRedirectFileReactRouterV5 = (params: GenerateRedirectFileReactRout
     from: `./${patternNamedExports.filename}`,
   })}
   const ${functionName}: React.FunctionComponent<${patternNamedExports.urlPartsInterfaceName} & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery);
+    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery, props.origin);
     return (
       <>
         <Redirect to={to} />

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
@@ -26,7 +26,7 @@ describe("generateUseRedirectReactRouterV5", () => {
   const useRedirectLogin = (): RedirectFnLogin => {
     const history = useHistory();
     const redirect: RedirectFnLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery);
+      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
       history.push(to);
     }
     return redirect;
@@ -60,7 +60,7 @@ describe("generateUseRedirectReactRouterV5", () => {
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const history = useHistory();
     const redirect: RedirectFnUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery);
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
       history.push(to);
     }
     return redirect;

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
@@ -30,7 +30,7 @@ const generateUseRedirectReactRouterV5 = (params: GenerateUseRedirectReactRouter
   const ${functionName} = (): ${resultTypeInterface} => {
     const history = useHistory();
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery);
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin);
       history.push(to);
     }
     return redirect;

--- a/src/generateUrl/generateUrl.test.ts
+++ b/src/generateUrl/generateUrl.test.ts
@@ -101,4 +101,11 @@ describe("generateUrl", () => {
       expect(result).toBe("/app/users/oneHundo?from=homepage&redirect=/login");
     });
   });
+
+  describe("with prefix", () => {
+    it("should generate url with prefix", () => {
+      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage" }, "https://test.domain");
+      expect(result).toBe("https://test.domain/app/users/oneHundo?from=homepage");
+    });
+  });
 });

--- a/src/generateUrl/generateUrl.ts
+++ b/src/generateUrl/generateUrl.ts
@@ -33,8 +33,9 @@ const generateQueryString = (urlQuery?: Record<string, string>): string => {
   return result.substring(0, result.length - 1);
 };
 
-export type GenerateUrl = <P>(pattern: string, inputParams: P, urlQuery?: Record<string, string>) => string;
-const generateUrl: GenerateUrl = (pattern, inputParams, urlQuery) =>
-  generatePath(pattern, inputParams as any) + generateQueryString(urlQuery);
+export type GenerateUrl = <P>(pattern: string, inputParams: P, urlQuery?: Record<string, string>, origin?: string) => string;
+const generateUrl: GenerateUrl = (pattern, inputParams, urlQuery, origin) => {
+  return (origin ?? "") + generatePath(pattern, inputParams as any) + generateQueryString(urlQuery);
+};
 
 export default generateUrl;


### PR DESCRIPTION
## Util functions

- Add optional url origin to `generateUrl`

## Templates

- Support optional url origin for `Link*`, `Redirect*` and `useRedirect`

