### PR TITLE
Support environment variable, fix external route module origin value

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ apps:
       legacyApp: /legacy/app
 
   # Origin can be used to prefix the URL path of certain apps.
-  # Note that this value is used as template literals, so environment variables can be used.
+  # ${...} Can be used to pass environment variables to the config yml
   externalApp:
-    origin: https://${process.env.SUB_DOMAIN}.external.com
+    origin: https://${SUB_DOMAIN}.external.com
     routes:
       externalAppHome: /
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "generate:sample": "rm -rf ./sample/output && rm -rf ./sample/output-with-origins && yarn --silent build && node dist/bin/route-codegen.js --stacktrace --verbose --config sample/routegen.yml && node dist/bin/route-codegen.js --stacktrace --verbose --config sample/routegen-with-origins.yml && yarn --silent format:sample --loglevel silent ",
+    "generate:sample": "rm -rf ./sample/output && rm -rf ./sample/output-with-origins && yarn --silent build && node dist/bin/route-codegen.js --stacktrace --verbose --config sample/routegen.yml && PRIMARY_DOMAIN=domain.com node dist/bin/route-codegen.js --stacktrace --verbose --config sample/routegen-with-origins.yml && yarn --silent format:sample --loglevel silent ",
     "build": "yarn build:main && yarn build:root",
     "build:main": "rm -rf ./dist && tsc",
     "build:root": "yarn build:rootDist && yarn build:rootFiles",

--- a/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://app.domain.com`;
+export const originActivateAccount = "https://app.domain.com";
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originActivateAccount = `https://app.domain.com`;
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = "https://app.domain.com";
+export const originActivateAccount = "https://api.domain.com";
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = "https://app.domain.com";
+export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://app.domain.com`;
+export const originGraphql = "https://app.domain.com";
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originGraphql = `https://app.domain.com`;
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/home/patternHome.ts
+++ b/sample/output-with-origins/app/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://app.domain.com`;
+export const originHome = "https://app.domain.com";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/home/patternHome.ts
+++ b/sample/output-with-origins/app/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = "https://app.domain.com";
+export const originHome = "https://domain.com";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/home/patternHome.ts
+++ b/sample/output-with-origins/app/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originHome = `https://app.domain.com`;
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originLegacy = `https://app.domain.com`;
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = "https://app.domain.com";
+export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://app.domain.com`;
+export const originLegacy = "https://app.domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originTerms = `https://app.domain.com`;
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = "https://app.domain.com";
+export const originTerms = "https://domain.com";
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://app.domain.com`;
+export const originTerms = "https://app.domain.com";
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/app/routes/user/patternUser.ts
+++ b/sample/output-with-origins/app/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://app.domain.com`;
+export const originUser = "https://app.domain.com";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/app/routes/user/patternUser.ts
+++ b/sample/output-with-origins/app/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://app.${process.env.REACT_APP_MAIN_DOMAIN}`;
+export const originUser = `https://app.domain.com`;
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originActivateAccount = `https://domain.com`;
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://domain.com`;
+export const originActivateAccount = "https://domain.com";
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = "https://domain.com";
+export const originActivateAccount = "https://api.domain.com";
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://domain.com`;
+export const originGraphql = "https://domain.com";
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originGraphql = `https://domain.com`;
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = "https://domain.com";
+export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/home/patternHome.ts
+++ b/sample/output-with-origins/seo/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originHome = `https://domain.com`;
 export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {

--- a/sample/output-with-origins/seo/routes/home/patternHome.ts
+++ b/sample/output-with-origins/seo/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://domain.com`;
+export const originHome = "https://domain.com";
 export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {

--- a/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = "https://domain.com";
+export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originLegacy = `https://domain.com`;
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://domain.com`;
+export const originLegacy = "https://domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/seo/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/seo/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://domain.com`;
+export const originTerms = "https://domain.com";
 export const patternNextJSTerms = "/terms";
 
 export interface UrlPartsTerms {

--- a/sample/output-with-origins/seo/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/seo/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originTerms = `https://domain.com`;
 export const patternNextJSTerms = "/terms";
 
 export interface UrlPartsTerms {

--- a/sample/output-with-origins/seo/routes/user/patternUser.ts
+++ b/sample/output-with-origins/seo/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://domain.com`;
+export const originUser = "https://domain.com";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/seo/routes/user/patternUser.ts
+++ b/sample/output-with-origins/seo/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}`;
+export const originUser = `https://domain.com`;
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/seo/routes/user/patternUser.ts
+++ b/sample/output-with-origins/seo/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = "https://domain.com";
+export const originUser = "https://app.domain.com";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://api.${MAIN_DOMAIN}`;
+export const originActivateAccount = `https://api.domain.com`;
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
-export const originActivateAccount = `https://api.domain.com`;
+export const originActivateAccount = "https://api.domain.com";
 
 export type PathParamsActivateAccount = { code: string };
 

--- a/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://api.domain.com`;
+export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternGraphql = "/graphql";
-export const originGraphql = `https://api.${MAIN_DOMAIN}`;
+export const originGraphql = `https://api.domain.com`;
 
 export interface UrlPartsGraphql {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/home/patternHome.ts
+++ b/sample/output-with-origins/server/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = "https://api.domain.com";
+export const originHome = "https://domain.com";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/home/patternHome.ts
+++ b/sample/output-with-origins/server/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://api.domain.com`;
+export const originHome = "https://api.domain.com";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/home/patternHome.ts
+++ b/sample/output-with-origins/server/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = `https://api.${MAIN_DOMAIN}`;
+export const originHome = `https://api.domain.com`;
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://api.domain.com`;
+export const originLegacy = "https://api.domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = "https://api.domain.com";
+export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = `https://api.${MAIN_DOMAIN}`;
+export const originLegacy = `https://api.domain.com`;
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://api.domain.com`;
+export const originTerms = "https://api.domain.com";
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = `https://api.${MAIN_DOMAIN}`;
+export const originTerms = `https://api.domain.com`;
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/patternTerms.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
-export const originTerms = "https://api.domain.com";
+export const originTerms = "https://domain.com";
 
 export interface UrlPartsTerms {
   urlQuery?: Record<string, string>;

--- a/sample/output-with-origins/server/routes/user/patternUser.ts
+++ b/sample/output-with-origins/server/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://api.domain.com`;
+export const originUser = "https://api.domain.com";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/server/routes/user/patternUser.ts
+++ b/sample/output-with-origins/server/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = "https://api.domain.com";
+export const originUser = "https://app.domain.com";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output-with-origins/server/routes/user/patternUser.ts
+++ b/sample/output-with-origins/server/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
-export const originUser = `https://api.${MAIN_DOMAIN}`;
+export const originUser = `https://api.domain.com`;
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output/app/routes/about/patternAbout.ts
+++ b/sample/output/app/routes/about/patternAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
-export const originAbout = ``;
+export const originAbout = "";
 
 export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 

--- a/sample/output/app/routes/account/patternAccount.ts
+++ b/sample/output/app/routes/account/patternAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAccount = "/app/account";
-export const originAccount = ``;
+export const originAccount = "";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/home/patternHome.ts
+++ b/sample/output/app/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = ``;
+export const originHome = "";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/legacy/patternLegacy.ts
+++ b/sample/output/app/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = ``;
+export const originLegacy = "";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/login/patternLogin.ts
+++ b/sample/output/app/routes/login/patternLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLogin = "/login";
-export const originLogin = ``;
+export const originLogin = "";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/signup/patternSignup.ts
+++ b/sample/output/app/routes/signup/patternSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternSignup = "/signup";
-export const originSignup = ``;
+export const originSignup = "";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/toc/patternToc.ts
+++ b/sample/output/app/routes/toc/patternToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
-export const originToc = ``;
+export const originToc = "";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;

--- a/sample/output/app/routes/user/patternUser.ts
+++ b/sample/output/app/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
-export const originUser = ``;
+export const originUser = "";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output/auth/routes/about/patternAbout.ts
+++ b/sample/output/auth/routes/about/patternAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
-export const originAbout = ``;
+export const originAbout = "";
 
 export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 

--- a/sample/output/auth/routes/account/patternAccount.ts
+++ b/sample/output/auth/routes/account/patternAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAccount = "/app/account";
-export const originAccount = ``;
+export const originAccount = "";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/home/patternHome.ts
+++ b/sample/output/auth/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = ``;
+export const originHome = "";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/legacy/patternLegacy.ts
+++ b/sample/output/auth/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = ``;
+export const originLegacy = "";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/login/patternLogin.ts
+++ b/sample/output/auth/routes/login/patternLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLogin = "/login";
-export const originLogin = ``;
+export const originLogin = "";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/signup/patternSignup.ts
+++ b/sample/output/auth/routes/signup/patternSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternSignup = "/signup";
-export const originSignup = ``;
+export const originSignup = "";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/toc/patternToc.ts
+++ b/sample/output/auth/routes/toc/patternToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
-export const originToc = ``;
+export const originToc = "";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;

--- a/sample/output/auth/routes/user/patternUser.ts
+++ b/sample/output/auth/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
-export const originUser = ``;
+export const originUser = "";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output/seo/routes/about/patternAbout.ts
+++ b/sample/output/seo/routes/about/patternAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
-export const originAbout = ``;
+export const originAbout = "";
 export const patternNextJSAbout = "/about/[target]/[topic]/[optional]/[optionalEnum]";
 export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 export interface PathParamsNextJSAbout {

--- a/sample/output/seo/routes/account/patternAccount.ts
+++ b/sample/output/seo/routes/account/patternAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAccount = "/app/account";
-export const originAccount = ``;
+export const originAccount = "";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;

--- a/sample/output/seo/routes/home/patternHome.ts
+++ b/sample/output/seo/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = ``;
+export const originHome = "";
 export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {

--- a/sample/output/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output/seo/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = ``;
+export const originLegacy = "";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output/seo/routes/login/patternLogin.ts
+++ b/sample/output/seo/routes/login/patternLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLogin = "/login";
-export const originLogin = ``;
+export const originLogin = "";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;

--- a/sample/output/seo/routes/signup/patternSignup.ts
+++ b/sample/output/seo/routes/signup/patternSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternSignup = "/signup";
-export const originSignup = ``;
+export const originSignup = "";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;

--- a/sample/output/seo/routes/toc/patternToc.ts
+++ b/sample/output/seo/routes/toc/patternToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
-export const originToc = ``;
+export const originToc = "";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;

--- a/sample/output/seo/routes/user/patternUser.ts
+++ b/sample/output/seo/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
-export const originUser = ``;
+export const originUser = "";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output/server/routes/about/patternAbout.ts
+++ b/sample/output/server/routes/about/patternAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
-export const originAbout = ``;
+export const originAbout = "";
 
 export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 

--- a/sample/output/server/routes/account/patternAccount.ts
+++ b/sample/output/server/routes/account/patternAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAccount = "/app/account";
-export const originAccount = ``;
+export const originAccount = "";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/home/patternHome.ts
+++ b/sample/output/server/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = ``;
+export const originHome = "";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/legacy/patternLegacy.ts
+++ b/sample/output/server/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = ``;
+export const originLegacy = "";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/login/patternLogin.ts
+++ b/sample/output/server/routes/login/patternLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLogin = "/login";
-export const originLogin = ``;
+export const originLogin = "";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/signup/patternSignup.ts
+++ b/sample/output/server/routes/signup/patternSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternSignup = "/signup";
-export const originSignup = ``;
+export const originSignup = "";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/toc/patternToc.ts
+++ b/sample/output/server/routes/toc/patternToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
-export const originToc = ``;
+export const originToc = "";
 
 export interface UrlPartsToc {
   urlQuery?: Record<string, string>;

--- a/sample/output/server/routes/user/patternUser.ts
+++ b/sample/output/server/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
-export const originUser = ``;
+export const originUser = "";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/output/toc/routes/about/patternAbout.ts
+++ b/sample/output/toc/routes/about/patternAbout.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:optional?/:optionalEnum(enumOne|enumTwo)?";
-export const originAbout = ``;
+export const originAbout = "";
 
 export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: string; optionalEnum?: "enumOne" | "enumTwo" };
 

--- a/sample/output/toc/routes/account/patternAccount.ts
+++ b/sample/output/toc/routes/account/patternAccount.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAccount = "/app/account";
-export const originAccount = ``;
+export const originAccount = "";
 
 export interface UrlPartsAccount {
   urlQuery?: Record<string, string>;

--- a/sample/output/toc/routes/home/patternHome.ts
+++ b/sample/output/toc/routes/home/patternHome.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
-export const originHome = ``;
+export const originHome = "";
 
 export interface UrlPartsHome {
   urlQuery?: Record<string, string>;

--- a/sample/output/toc/routes/legacy/patternLegacy.ts
+++ b/sample/output/toc/routes/legacy/patternLegacy.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLegacy = "/legacy/app";
-export const originLegacy = ``;
+export const originLegacy = "";
 
 export interface UrlPartsLegacy {
   urlQuery?: Record<string, string>;

--- a/sample/output/toc/routes/login/patternLogin.ts
+++ b/sample/output/toc/routes/login/patternLogin.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternLogin = "/login";
-export const originLogin = ``;
+export const originLogin = "";
 
 export interface UrlPartsLogin {
   urlQuery?: Record<string, string>;

--- a/sample/output/toc/routes/signup/patternSignup.ts
+++ b/sample/output/toc/routes/signup/patternSignup.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternSignup = "/signup";
-export const originSignup = ``;
+export const originSignup = "";
 
 export interface UrlPartsSignup {
   urlQuery?: Record<string, string>;

--- a/sample/output/toc/routes/toc/patternToc.ts
+++ b/sample/output/toc/routes/toc/patternToc.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
-export const originToc = ``;
+export const originToc = "";
 export const patternNextJSToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {

--- a/sample/output/toc/routes/user/patternUser.ts
+++ b/sample/output/toc/routes/user/patternUser.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
-export const originUser = ``;
+export const originUser = "";
 
 export type PathParamsUser = { id: string; subview?: "pictures" };
 

--- a/sample/routegen-with-origins.yml
+++ b/sample/routegen-with-origins.yml
@@ -1,13 +1,13 @@
 apps:
   app:
-    origin: https://app.${process.env.REACT_APP_MAIN_DOMAIN}
+    origin: https://app.${PRIMARY_DOMAIN}
     routes:
       user: /users/:id/:subview(pictures)?
     routingType: ReactRouterV5
     destinationDir: sample/output-with-origins/app/routes
 
   seo:
-    origin: https://${process.env.NEXT_PUBLIC_MAIN_DOMAIN}
+    origin: https://${PRIMARY_DOMAIN}
     routes:
       home: /
       terms: /terms
@@ -20,7 +20,7 @@ apps:
       legacy: /legacy/app
 
   api:
-    origin: https://api.${MAIN_DOMAIN}
+    origin: https://api.${PRIMARY_DOMAIN}
     routes:
       graphql: /graphql
       activateAccount: /activate-account/:code

--- a/src/bin/route-codegen.ts
+++ b/src/bin/route-codegen.ts
@@ -4,6 +4,7 @@ import yargs from "yargs";
 import generate from "./../generate";
 import yaml from "js-yaml";
 import { readFileSync } from "fs";
+import { log } from "util";
 
 const argv = yargs.options({
   config: { type: "string", default: "route-codegen.yml" },
@@ -20,6 +21,7 @@ try {
   // Allow passing variables by replacing ${...} with its correspondent value in process.env
   if (typeof process !== "undefined" && "env" in process) {
     ymlContent = ymlContent.replace(/\$\{(.*)\}/g, (str, variable, index) => {
+      log(`Replacing \${${variable}} with ${process.env[variable]}`);
       return process.env[variable] ?? "";
     });
   }

--- a/src/bin/route-codegen.ts
+++ b/src/bin/route-codegen.ts
@@ -15,7 +15,14 @@ const { config, stacktrace, verbose } = argv;
 
 try {
   console.log("route-codegen START!");
-  const ymlContent = readFileSync(config, "utf8");
+  let ymlContent = readFileSync(config, "utf8");
+
+  // Allow passing variables by replacing ${...} with its correspondent value in process.env
+  if (typeof process !== "undefined" && "env" in process) {
+    ymlContent = ymlContent.replace(/\$\{(.*)\}/g, (str, variable, index) => {
+      return process.env[variable] ?? "";
+    });
+  }
 
   const configContent = yaml.safeLoad(ymlContent);
   generate(configContent, { verbose });

--- a/src/generate/config/config.ts
+++ b/src/generate/config/config.ts
@@ -20,9 +20,15 @@ interface LinkOptions {
   generateUseParams?: boolean;
 }
 
+// TODO: The Object version is only being used internally when generating external routes. Test if it's safe for users to use
+export interface AppRoute {
+  path: string;
+  origin: string;
+}
+
 export interface AppConfig {
   origin?: string;
-  routes?: Record<string, string>;
+  routes?: Record<string, string | AppRoute>;
   routingType?: string;
   destinationDir?: string;
   reactRouterV5LinkOptions?: LinkOptions;

--- a/src/generate/generateAppFiles/generateAppFiles.ts
+++ b/src/generate/generateAppFiles/generateAppFiles.ts
@@ -5,7 +5,7 @@ import parseAppConfig from "./parseAppConfig";
 import info from "../utils/info";
 
 const generateAppFiles = (appName: string, app: AppConfig): TemplateFile[] => {
-  const { routes, routingType, destinationDir, routeLinkOptions, importGenerateUrl, importRedirectServerSide, origin } = parseAppConfig(
+  const { routes, routingType, destinationDir, routeLinkOptions, importGenerateUrl, importRedirectServerSide } = parseAppConfig(
     appName,
     app
   );
@@ -13,10 +13,10 @@ const generateAppFiles = (appName: string, app: AppConfig): TemplateFile[] => {
   if (destinationDir) {
     const files: TemplateFile[][] = Object.entries(routes).map(([routeName, routePattern]) =>
       generateTemplateFiles({
-        origin,
+        origin: routePattern.origin,
+        routePattern: routePattern.path,
         routeName,
         routeLinkOptions,
-        routePattern,
         destinationDir,
         routingType,
         importGenerateUrl,

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
@@ -38,7 +38,7 @@ describe("generatePatternFile", () => {
       expect(templateFile.destinationDir).toBe("path/to/routes");
       expect(templateFile.template).toContain(
         `export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
-  export const originUserInfo = \`\`
+  export const originUserInfo = ''
   
   export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
   
@@ -75,7 +75,7 @@ describe("generatePatternFile", () => {
       expect(templateFile.destinationDir).toBe("path/to/routes");
       expect(templateFile.template)
         .toContain(`export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)/:optional?/:optionalEnum(enum1|enum2)?'
-  export const originUserInfo = \`\`
+  export const originUserInfo = ''
   export const patternNextJSUserInfo = '/app/users/[id]/[subview]/[optional]/[optionalEnum]'
   export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';optional?: string;optionalEnum?:'enum1'|'enum2';}
   export interface PathParamsNextJSUserInfo {id: string;subview: string;optional?: string;optionalEnum?: string;}
@@ -113,42 +113,7 @@ describe("generatePatternFile", () => {
       expect(templateFile.destinationDir).toBe("path/to/routes");
       expect(templateFile.template).toContain(
         `export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
-  export const originUserInfo = \`https://sample.domain.com\`
-  
-  export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
-  
-  export const possilePathParamsUserInfo = ['id','subview',]
-  export interface UrlPartsUserInfo {
-    path: PathParamsUserInfo;
-    urlQuery?: Record<string, string>;
-    origin?: string;
-  }`
-      );
-      expect(interfaceResult).toEqual({
-        originName: "originUserInfo",
-        patternName: "patternUserInfo",
-        pathParamsInterfaceName: "PathParamsUserInfo",
-        urlPartsInterfaceName: "UrlPartsUserInfo",
-        filename: "patternUserInfo",
-        possiblePathParamsVariableName: "possilePathParamsUserInfo",
-      });
-    });
-
-    it("should handle origin with template dynamic values correctly", () => {
-      const [templateFile, interfaceResult] = generatePatternFile({
-        origin: "https://app.${process.env.REACT_APP_MAIN_DOMAIN}",
-        routePattern: "/app/users/:id/:subview(profile|pictures)",
-        destinationDir: "path/to/routes",
-        routeName: "UserInfo",
-        routingType: RoutingType.Default,
-      });
-
-      expect(templateFile.filename).toBe("patternUserInfo");
-      expect(templateFile.extension).toBe(".ts");
-      expect(templateFile.destinationDir).toBe("path/to/routes");
-      expect(templateFile.template).toContain(
-        `export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
-  export const originUserInfo = \`https://app.\${process.env.REACT_APP_MAIN_DOMAIN}\`
+  export const originUserInfo = 'https://sample.domain.com'
   
   export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
   

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -31,7 +31,7 @@ const generateRoutePatternFile = (params: GenerateRoutePatternFileParams): [Temp
   const pathParamsNextJS = routingType === RoutingType.NextJS ? generateNextJSPathParams(keys, routeName) : null;
 
   const template = `export const ${patternName} = '${routePattern}'
-  export const ${originName} = \`${origin}\`
+  export const ${originName} = '${origin}'
   ${patternNextJS ? patternNextJS.template : ""}
   ${pathParams ? pathParams.template : ""}
   ${pathParamsNextJS ? pathParamsNextJS.template : ""}

--- a/src/generate/generateAppFiles/parseAppConfig.test.ts
+++ b/src/generate/generateAppFiles/parseAppConfig.test.ts
@@ -52,10 +52,15 @@ describe("parseAppConfig", () => {
       const parsedConfig = parseAppConfig("sampleApp", { ...defaultAppConfig });
 
       expect(parsedConfig).toEqual({
-        origin: "",
         routes: {
-          login: "/login",
-          user: "/user/:id",
+          login: {
+            origin: "",
+            path: "/login",
+          },
+          user: {
+            origin: "",
+            path: "/user/:id",
+          },
         },
         destinationDir: "path/to/routes",
         routingType: RoutingType.Default,

--- a/src/generate/generateExternalRoutesConfig/generateExternalRoutesConfig.test.ts
+++ b/src/generate/generateExternalRoutesConfig/generateExternalRoutesConfig.test.ts
@@ -5,6 +5,7 @@ describe("generateExternalRoutesConfig", () => {
   it("should generate external app route objects correctly", () => {
     const apps: Record<string, AppConfig> = {
       main: {
+        origin: "https://app.domain.com",
         routes: {
           login: "/app/login",
           signup: "/app/signup",
@@ -21,7 +22,14 @@ describe("generateExternalRoutesConfig", () => {
         destinationDir: "seo/src/routes",
         routingType: RoutingType.NextJS,
       },
+      server: {
+        routes: {
+          payments: "/payments",
+        },
+        destinationDir: "server/src/routes",
+      },
       legacy: {
+        origin: "https://legacy.domain.com",
         routes: {
           legacyBooks: "/legacy/books",
         },
@@ -31,31 +39,113 @@ describe("generateExternalRoutesConfig", () => {
     const externalRoutes = generateExternalRoutesConfig(apps);
     expect(externalRoutes).toStrictEqual({
       main: {
+        origin: undefined,
         routes: {
-          home: "/",
-          about: "/about",
-          users: "/:id/:subview(profile|pictures)",
-          legacyBooks: "/legacy/books",
+          home: {
+            origin: "",
+            path: "/",
+          },
+          about: {
+            origin: "",
+            path: "/about",
+          },
+          users: {
+            origin: "",
+            path: "/:id/:subview(profile|pictures)",
+          },
+          payments: {
+            origin: "",
+            path: "/payments",
+          },
+          legacyBooks: {
+            origin: "https://legacy.domain.com",
+            path: "/legacy/books",
+          },
         },
         destinationDir: "main/src/routes",
         routingType: RoutingType.Default,
       },
       seo: {
+        origin: undefined,
         routes: {
-          login: "/app/login",
-          signup: "/app/signup",
-          legacyBooks: "/legacy/books",
+          login: {
+            origin: "https://app.domain.com",
+            path: "/app/login",
+          },
+          signup: {
+            origin: "https://app.domain.com",
+            path: "/app/signup",
+          },
+          payments: {
+            origin: "",
+            path: "/payments",
+          },
+          legacyBooks: {
+            origin: "https://legacy.domain.com",
+            path: "/legacy/books",
+          },
         },
         destinationDir: "seo/src/routes",
         routingType: RoutingType.Default,
       },
-      legacy: {
+      server: {
+        origin: undefined,
         routes: {
-          login: "/app/login",
-          signup: "/app/signup",
-          home: "/",
-          about: "/about",
-          users: "/:id/:subview(profile|pictures)",
+          login: {
+            origin: "https://app.domain.com",
+            path: "/app/login",
+          },
+          signup: {
+            origin: "https://app.domain.com",
+            path: "/app/signup",
+          },
+          home: {
+            origin: "",
+            path: "/",
+          },
+          about: {
+            origin: "",
+            path: "/about",
+          },
+          users: {
+            origin: "",
+            path: "/:id/:subview(profile|pictures)",
+          },
+          legacyBooks: {
+            origin: "https://legacy.domain.com",
+            path: "/legacy/books",
+          },
+        },
+        destinationDir: "server/src/routes",
+        routingType: RoutingType.Default,
+      },
+      legacy: {
+        origin: undefined,
+        routes: {
+          login: {
+            origin: "https://app.domain.com",
+            path: "/app/login",
+          },
+          signup: {
+            origin: "https://app.domain.com",
+            path: "/app/signup",
+          },
+          home: {
+            origin: "",
+            path: "/",
+          },
+          about: {
+            origin: "",
+            path: "/about",
+          },
+          users: {
+            origin: "",
+            path: "/:id/:subview(profile|pictures)",
+          },
+          payments: {
+            origin: "",
+            path: "/payments",
+          },
         },
         routingType: RoutingType.Default,
       },


### PR DESCRIPTION
## Config

- Variables with the format `${...}` in yml can now be replaced by the environment variables with the same name.

## Template

- `origin*` variables are no longer handled with template literals because we now support variables

## Samples

- Update "with origins" sample to use environment variables

## Internal change

- App routes can now be an object with keys `path`, `origin`. Technically these can be passed in from config yaml but it hasn't been tested how or if it works. This is being used interally to generate external route modules