### PR TITLE
Fix problem of path being destructured when there is none

### DIFF
--- a/sample/output-with-origins/seo/routes/home/LinkHome.tsx
+++ b/sample/output-with-origins/seo/routes/home/LinkHome.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
+  const { urlQuery = {}, ...rest } = props;
+  const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
     pathname: pathname,
@@ -12,6 +14,6 @@ const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ path = {}, urlQuery 
       ...urlQuery,
     },
   };
-  return <Link {...props} href={nextHref} />;
+  return <Link {...rest} href={nextHref} />;
 };
 export default LinkHome;

--- a/sample/output-with-origins/seo/routes/terms/LinkTerms.tsx
+++ b/sample/output-with-origins/seo/routes/terms/LinkTerms.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlPartsTerms, patternNextJSTerms } from "./patternTerms";
 type LinkTermsProps = Omit<LinkProps, "href"> & UrlPartsTerms;
-const LinkTerms: React.FunctionComponent<LinkTermsProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+const LinkTerms: React.FunctionComponent<LinkTermsProps> = (props) => {
+  const { urlQuery = {}, ...rest } = props;
+  const path = {};
   const pathname = patternNextJSTerms;
   const nextHref = {
     pathname: pathname,
@@ -12,6 +14,6 @@ const LinkTerms: React.FunctionComponent<LinkTermsProps> = ({ path = {}, urlQuer
       ...urlQuery,
     },
   };
-  return <Link {...props} href={nextHref} />;
+  return <Link {...rest} href={nextHref} />;
 };
 export default LinkTerms;

--- a/sample/output/seo/routes/about/LinkAbout.tsx
+++ b/sample/output/seo/routes/about/LinkAbout.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlPartsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<LinkProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = (props) => {
+  const { path = {}, urlQuery = {}, ...rest } = props;
   const pathname = possilePathParamsAbout
     .filter((key) => !(key in path))
     .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);
@@ -14,6 +15,6 @@ const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path = {}, urlQuer
       ...urlQuery,
     },
   };
-  return <Link {...props} href={nextHref} />;
+  return <Link {...rest} href={nextHref} />;
 };
 export default LinkAbout;

--- a/sample/output/seo/routes/home/LinkHome.tsx
+++ b/sample/output/seo/routes/home/LinkHome.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
+  const { urlQuery = {}, ...rest } = props;
+  const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
     pathname: pathname,
@@ -12,6 +14,6 @@ const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ path = {}, urlQuery 
       ...urlQuery,
     },
   };
-  return <Link {...props} href={nextHref} />;
+  return <Link {...rest} href={nextHref} />;
 };
 export default LinkHome;

--- a/sample/output/toc/routes/toc/LinkToc.tsx
+++ b/sample/output/toc/routes/toc/LinkToc.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import Link, { LinkProps } from "src/common/components/Link";
 import { UrlPartsToc, patternNextJSToc } from "./patternToc";
 type LinkTocProps = Omit<LinkProps, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkTocProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+const LinkToc: React.FunctionComponent<LinkTocProps> = (props) => {
+  const { urlQuery = {}, ...rest } = props;
+  const path = {};
   const pathname = patternNextJSToc;
   const nextHref = {
     pathname: pathname,
@@ -12,6 +14,6 @@ const LinkToc: React.FunctionComponent<LinkTocProps> = ({ path = {}, urlQuery = 
       ...urlQuery,
     },
   };
-  return <Link {...props} href={nextHref} />;
+  return <Link {...rest} href={nextHref} />;
 };
 export default LinkToc;

--- a/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
@@ -38,7 +38,8 @@ describe("generateLinkFileNextJS", () => {
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
   import {UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
+    const { urlQuery = {}, ...rest } = props; const path = {};
     const pathname = patternNextJSLogin;
     const nextHref = {
       pathname: pathname,
@@ -47,7 +48,7 @@ describe("generateLinkFileNextJS", () => {
         ...urlQuery,
       },
     }
-    return <Link {...props} customHref={nextHref} />;
+    return <Link {...rest} customHref={nextHref} />;
   }
   export default LinkLogin;`);
     });
@@ -69,7 +70,8 @@ describe("generateLinkFileNextJS", () => {
   import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
   import {UrlPartsLogin,patternNextJSLogin,possiblePathParamsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
+    const { path = {}, urlQuery = {}, ...rest } = props;
     const pathname = possiblePathParamsLogin.filter((key) => !(key in path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), patternNextJSLogin);
     const nextHref = {
       pathname: pathname,
@@ -78,7 +80,7 @@ describe("generateLinkFileNextJS", () => {
         ...urlQuery,
       },
     }
-    return <Link {...props} customHref={nextHref} />;
+    return <Link {...rest} customHref={nextHref} />;
   }
   export default LinkLogin;`);
     });
@@ -107,7 +109,8 @@ describe("generateLinkFileNextJS", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path = {}, urlQuery = {}, ...props }) => {
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
+    const { urlQuery = {}, ...rest } = props; const path = {};
     const pathname = patternNextJSLogin;
     const nextHref = {
       pathname: pathname,
@@ -116,7 +119,7 @@ describe("generateLinkFileNextJS", () => {
         ...urlQuery,
       },
     }
-    return <Link {...props} to={nextHref} />;
+    return <Link {...rest} to={nextHref} />;
   }
   export default LinkLogin;`);
     });


### PR DESCRIPTION
## Template

- Fix NextJS `Link` generator which does not destructure `path` correctly when pattern does not contain `path`