### PR TITLE
Rename urlQuery to query

### DIFF
--- a/sample/output-with-origins/app/routes/activateAccount/LinkActivateAccount.tsx
+++ b/sample/output-with-origins/app/routes/activateAccount/LinkActivateAccount.tsx
@@ -5,8 +5,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> &
   UrlPartsActivateAccount;
-const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternActivateAccount, path, urlQuery, origin ?? originActivateAccount);
+const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternActivateAccount, path, query, origin ?? originActivateAccount);
   return <a {...props} href={to} />;
 };
 export default LinkActivateAccount;

--- a/sample/output-with-origins/app/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/output-with-origins/app/routes/activateAccount/RedirectActivateAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const RedirectActivateAccount: React.FunctionComponent<UrlPartsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, props.path, props.urlQuery, props.origin ?? originActivateAccount);
+  const to = generateUrl(patternActivateAccount, props.path, props.query, props.origin ?? originActivateAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectActivateAccount;

--- a/sample/output-with-origins/app/routes/activateAccount/generateUrlActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/generateUrlActivateAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const generateUrlActivateAccount = (urlParts: UrlPartsActivateAccount): string =>
-  generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+  generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
 export default generateUrlActivateAccount;

--- a/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/patternActivateAccount.ts
@@ -7,6 +7,6 @@ export type PathParamsActivateAccount = { code: string };
 export const possilePathParamsActivateAccount = ["code"];
 export interface UrlPartsActivateAccount {
   path: PathParamsActivateAccount;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/activateAccount/useRedirectActivateAccount.ts
+++ b/sample/output-with-origins/app/routes/activateAccount/useRedirectActivateAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnActivateAccount = (urlParts: UrlPartsActivateAccount) => void;
 const useRedirectActivateAccount = (): RedirectFnActivateAccount => {
   const redirect: RedirectFnActivateAccount = (urlParts) => {
-    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/app/routes/graphql/LinkGraphql.tsx
+++ b/sample/output-with-origins/app/routes/graphql/LinkGraphql.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsGraphql;
-const LinkGraphql: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternGraphql, {}, urlQuery, origin ?? originGraphql);
+const LinkGraphql: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternGraphql, {}, query, origin ?? originGraphql);
   return <a {...props} href={to} />;
 };
 export default LinkGraphql;

--- a/sample/output-with-origins/app/routes/graphql/RedirectGraphql.tsx
+++ b/sample/output-with-origins/app/routes/graphql/RedirectGraphql.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
 const RedirectGraphql: React.FunctionComponent<UrlPartsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, {}, props.urlQuery, props.origin ?? originGraphql);
+  const to = generateUrl(patternGraphql, {}, props.query, props.origin ?? originGraphql);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectGraphql;

--- a/sample/output-with-origins/app/routes/graphql/generateUrlGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/generateUrlGraphql.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 const generateUrlGraphql = (urlParts?: UrlPartsGraphql): string =>
-  generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+  generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
 export default generateUrlGraphql;

--- a/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/patternGraphql.ts
@@ -3,6 +3,6 @@ export const patternGraphql = "/graphql";
 export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/graphql/useRedirectGraphql.ts
+++ b/sample/output-with-origins/app/routes/graphql/useRedirectGraphql.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnGraphql = (urlParts?: UrlPartsGraphql) => void;
 const useRedirectGraphql = (): RedirectFnGraphql => {
   const redirect: RedirectFnGraphql = (urlParts) => {
-    const to = generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+    const to = generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/app/routes/home/LinkHome.tsx
+++ b/sample/output-with-origins/app/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output-with-origins/app/routes/home/RedirectHome.tsx
+++ b/sample/output-with-origins/app/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output-with-origins/app/routes/home/generateUrlHome.ts
+++ b/sample/output-with-origins/app/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output-with-origins/app/routes/home/patternHome.ts
+++ b/sample/output-with-origins/app/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "https://domain.com";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/home/useRedirectHome.ts
+++ b/sample/output-with-origins/app/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/output-with-origins/app/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output-with-origins/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output-with-origins/app/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output-with-origins/app/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output-with-origins/app/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/app/routes/terms/LinkTerms.tsx
+++ b/sample/output-with-origins/app/routes/terms/LinkTerms.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternTerms, UrlPartsTerms, originTerms } from "./patternTerms";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsTerms;
-const LinkTerms: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternTerms, {}, urlQuery, origin ?? originTerms);
+const LinkTerms: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternTerms, {}, query, origin ?? originTerms);
   return <a {...props} href={to} />;
 };
 export default LinkTerms;

--- a/sample/output-with-origins/app/routes/terms/RedirectTerms.tsx
+++ b/sample/output-with-origins/app/routes/terms/RedirectTerms.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsTerms, patternTerms, originTerms } from "./patternTerms";
 const RedirectTerms: React.FunctionComponent<UrlPartsTerms & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternTerms, {}, props.urlQuery, props.origin ?? originTerms);
+  const to = generateUrl(patternTerms, {}, props.query, props.origin ?? originTerms);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectTerms;

--- a/sample/output-with-origins/app/routes/terms/generateUrlTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/generateUrlTerms.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternTerms, UrlPartsTerms, originTerms } from "./patternTerms";
 const generateUrlTerms = (urlParts?: UrlPartsTerms): string =>
-  generateUrl(patternTerms, {}, urlParts?.urlQuery, urlParts?.origin ?? originTerms);
+  generateUrl(patternTerms, {}, urlParts?.query, urlParts?.origin ?? originTerms);
 export default generateUrlTerms;

--- a/sample/output-with-origins/app/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/patternTerms.ts
@@ -3,6 +3,6 @@ export const patternTerms = "/terms";
 export const originTerms = "https://domain.com";
 
 export interface UrlPartsTerms {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/terms/useRedirectTerms.ts
+++ b/sample/output-with-origins/app/routes/terms/useRedirectTerms.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnTerms = (urlParts?: UrlPartsTerms) => void;
 const useRedirectTerms = (): RedirectFnTerms => {
   const redirect: RedirectFnTerms = (urlParts) => {
-    const to = generateUrl(patternTerms, {}, urlParts?.urlQuery, urlParts?.origin ?? originTerms);
+    const to = generateUrl(patternTerms, {}, urlParts?.query, urlParts?.origin ?? originTerms);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/app/routes/user/LinkUser.tsx
+++ b/sample/output-with-origins/app/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<LinkProps, "to"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkUser;

--- a/sample/output-with-origins/app/routes/user/RedirectUser.tsx
+++ b/sample/output-with-origins/app/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output-with-origins/app/routes/user/generateUrlUser.ts
+++ b/sample/output-with-origins/app/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output-with-origins/app/routes/user/patternUser.ts
+++ b/sample/output-with-origins/app/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/app/routes/user/useRedirectUser.ts
+++ b/sample/output-with-origins/app/routes/user/useRedirectUser.ts
@@ -6,7 +6,7 @@ export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const history = useHistory();
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin);
     history.push(to);
   };
   return redirect;

--- a/sample/output-with-origins/seo/routes/activateAccount/LinkActivateAccount.tsx
+++ b/sample/output-with-origins/seo/routes/activateAccount/LinkActivateAccount.tsx
@@ -5,8 +5,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> &
   UrlPartsActivateAccount;
-const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternActivateAccount, path, urlQuery, origin ?? originActivateAccount);
+const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternActivateAccount, path, query, origin ?? originActivateAccount);
   return <a {...props} href={to} />;
 };
 export default LinkActivateAccount;

--- a/sample/output-with-origins/seo/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/output-with-origins/seo/routes/activateAccount/RedirectActivateAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const RedirectActivateAccount: React.FunctionComponent<UrlPartsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, props.path, props.urlQuery, props.origin ?? originActivateAccount);
+  const to = generateUrl(patternActivateAccount, props.path, props.query, props.origin ?? originActivateAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectActivateAccount;

--- a/sample/output-with-origins/seo/routes/activateAccount/generateUrlActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/generateUrlActivateAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const generateUrlActivateAccount = (urlParts: UrlPartsActivateAccount): string =>
-  generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+  generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
 export default generateUrlActivateAccount;

--- a/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/patternActivateAccount.ts
@@ -7,6 +7,6 @@ export type PathParamsActivateAccount = { code: string };
 export const possilePathParamsActivateAccount = ["code"];
 export interface UrlPartsActivateAccount {
   path: PathParamsActivateAccount;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/activateAccount/useRedirectActivateAccount.ts
+++ b/sample/output-with-origins/seo/routes/activateAccount/useRedirectActivateAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnActivateAccount = (urlParts: UrlPartsActivateAccount) => void;
 const useRedirectActivateAccount = (): RedirectFnActivateAccount => {
   const redirect: RedirectFnActivateAccount = (urlParts) => {
-    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/seo/routes/graphql/LinkGraphql.tsx
+++ b/sample/output-with-origins/seo/routes/graphql/LinkGraphql.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsGraphql;
-const LinkGraphql: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternGraphql, {}, urlQuery, origin ?? originGraphql);
+const LinkGraphql: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternGraphql, {}, query, origin ?? originGraphql);
   return <a {...props} href={to} />;
 };
 export default LinkGraphql;

--- a/sample/output-with-origins/seo/routes/graphql/RedirectGraphql.tsx
+++ b/sample/output-with-origins/seo/routes/graphql/RedirectGraphql.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
 const RedirectGraphql: React.FunctionComponent<UrlPartsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, {}, props.urlQuery, props.origin ?? originGraphql);
+  const to = generateUrl(patternGraphql, {}, props.query, props.origin ?? originGraphql);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectGraphql;

--- a/sample/output-with-origins/seo/routes/graphql/generateUrlGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/generateUrlGraphql.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 const generateUrlGraphql = (urlParts?: UrlPartsGraphql): string =>
-  generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+  generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
 export default generateUrlGraphql;

--- a/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/patternGraphql.ts
@@ -3,6 +3,6 @@ export const patternGraphql = "/graphql";
 export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/graphql/useRedirectGraphql.ts
+++ b/sample/output-with-origins/seo/routes/graphql/useRedirectGraphql.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnGraphql = (urlParts?: UrlPartsGraphql) => void;
 const useRedirectGraphql = (): RedirectFnGraphql => {
   const redirect: RedirectFnGraphql = (urlParts) => {
-    const to = generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+    const to = generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/seo/routes/home/LinkHome.tsx
+++ b/sample/output-with-origins/seo/routes/home/LinkHome.tsx
@@ -4,14 +4,14 @@ import Link, { LinkProps } from "next/link";
 import { UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
-  const { urlQuery = {}, ...rest } = props;
+  const { query = {}, ...rest } = props;
   const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
     pathname: pathname,
     query: {
       ...path,
-      ...urlQuery,
+      ...query,
     },
   };
   return <Link {...rest} href={nextHref} />;

--- a/sample/output-with-origins/seo/routes/home/generateUrlHome.ts
+++ b/sample/output-with-origins/seo/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output-with-origins/seo/routes/home/patternHome.ts
+++ b/sample/output-with-origins/seo/routes/home/patternHome.ts
@@ -4,6 +4,6 @@ export const originHome = "https://domain.com";
 export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/home/useRedirectHome.ts
+++ b/sample/output-with-origins/seo/routes/home/useRedirectHome.ts
@@ -5,7 +5,7 @@ export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const router = useRouter();
   const redirect: RedirectFnHome = (urlParts) => {
-    const query = urlParts?.urlQuery ?? {};
+    const query = urlParts?.query ?? {};
     const path = {};
     const pathname = patternNextJSHome;
     router.push({

--- a/sample/output-with-origins/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/output-with-origins/seo/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output-with-origins/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output-with-origins/seo/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output-with-origins/seo/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output-with-origins/seo/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/seo/routes/terms/LinkTerms.tsx
+++ b/sample/output-with-origins/seo/routes/terms/LinkTerms.tsx
@@ -4,14 +4,14 @@ import Link, { LinkProps } from "next/link";
 import { UrlPartsTerms, patternNextJSTerms } from "./patternTerms";
 type LinkTermsProps = Omit<LinkProps, "href"> & UrlPartsTerms;
 const LinkTerms: React.FunctionComponent<LinkTermsProps> = (props) => {
-  const { urlQuery = {}, ...rest } = props;
+  const { query = {}, ...rest } = props;
   const path = {};
   const pathname = patternNextJSTerms;
   const nextHref = {
     pathname: pathname,
     query: {
       ...path,
-      ...urlQuery,
+      ...query,
     },
   };
   return <Link {...rest} href={nextHref} />;

--- a/sample/output-with-origins/seo/routes/terms/generateUrlTerms.ts
+++ b/sample/output-with-origins/seo/routes/terms/generateUrlTerms.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternTerms, UrlPartsTerms, originTerms } from "./patternTerms";
 const generateUrlTerms = (urlParts?: UrlPartsTerms): string =>
-  generateUrl(patternTerms, {}, urlParts?.urlQuery, urlParts?.origin ?? originTerms);
+  generateUrl(patternTerms, {}, urlParts?.query, urlParts?.origin ?? originTerms);
 export default generateUrlTerms;

--- a/sample/output-with-origins/seo/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/seo/routes/terms/patternTerms.ts
@@ -4,6 +4,6 @@ export const originTerms = "https://domain.com";
 export const patternNextJSTerms = "/terms";
 
 export interface UrlPartsTerms {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/terms/useRedirectTerms.ts
+++ b/sample/output-with-origins/seo/routes/terms/useRedirectTerms.ts
@@ -5,7 +5,7 @@ export type RedirectFnTerms = (urlParts?: UrlPartsTerms) => void;
 const useRedirectTerms = (): RedirectFnTerms => {
   const router = useRouter();
   const redirect: RedirectFnTerms = (urlParts) => {
-    const query = urlParts?.urlQuery ?? {};
+    const query = urlParts?.query ?? {};
     const path = {};
     const pathname = patternNextJSTerms;
     router.push({

--- a/sample/output-with-origins/seo/routes/user/LinkUser.tsx
+++ b/sample/output-with-origins/seo/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output-with-origins/seo/routes/user/RedirectUser.tsx
+++ b/sample/output-with-origins/seo/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output-with-origins/seo/routes/user/generateUrlUser.ts
+++ b/sample/output-with-origins/seo/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output-with-origins/seo/routes/user/patternUser.ts
+++ b/sample/output-with-origins/seo/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/seo/routes/user/useRedirectUser.ts
+++ b/sample/output-with-origins/seo/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/activateAccount/LinkActivateAccount.tsx
+++ b/sample/output-with-origins/server/routes/activateAccount/LinkActivateAccount.tsx
@@ -5,8 +5,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> &
   UrlPartsActivateAccount;
-const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternActivateAccount, path, urlQuery, origin ?? originActivateAccount);
+const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternActivateAccount, path, query, origin ?? originActivateAccount);
   return <a {...props} href={to} />;
 };
 export default LinkActivateAccount;

--- a/sample/output-with-origins/server/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/output-with-origins/server/routes/activateAccount/RedirectActivateAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const RedirectActivateAccount: React.FunctionComponent<UrlPartsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, props.path, props.urlQuery, props.origin ?? originActivateAccount);
+  const to = generateUrl(patternActivateAccount, props.path, props.query, props.origin ?? originActivateAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectActivateAccount;

--- a/sample/output-with-origins/server/routes/activateAccount/generateUrlActivateAccount.ts
+++ b/sample/output-with-origins/server/routes/activateAccount/generateUrlActivateAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternActivateAccount, UrlPartsActivateAccount, originActivateAccount } from "./patternActivateAccount";
 const generateUrlActivateAccount = (urlParts: UrlPartsActivateAccount): string =>
-  generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+  generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
 export default generateUrlActivateAccount;

--- a/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/output-with-origins/server/routes/activateAccount/patternActivateAccount.ts
@@ -7,6 +7,6 @@ export type PathParamsActivateAccount = { code: string };
 export const possilePathParamsActivateAccount = ["code"];
 export interface UrlPartsActivateAccount {
   path: PathParamsActivateAccount;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/activateAccount/useRedirectActivateAccount.ts
+++ b/sample/output-with-origins/server/routes/activateAccount/useRedirectActivateAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnActivateAccount = (urlParts: UrlPartsActivateAccount) => void;
 const useRedirectActivateAccount = (): RedirectFnActivateAccount => {
   const redirect: RedirectFnActivateAccount = (urlParts) => {
-    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originActivateAccount);
+    const to = generateUrl(patternActivateAccount, urlParts.path, urlParts?.query, urlParts?.origin ?? originActivateAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/graphql/LinkGraphql.tsx
+++ b/sample/output-with-origins/server/routes/graphql/LinkGraphql.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsGraphql;
-const LinkGraphql: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternGraphql, {}, urlQuery, origin ?? originGraphql);
+const LinkGraphql: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternGraphql, {}, query, origin ?? originGraphql);
   return <a {...props} href={to} />;
 };
 export default LinkGraphql;

--- a/sample/output-with-origins/server/routes/graphql/RedirectGraphql.tsx
+++ b/sample/output-with-origins/server/routes/graphql/RedirectGraphql.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
 const RedirectGraphql: React.FunctionComponent<UrlPartsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, {}, props.urlQuery, props.origin ?? originGraphql);
+  const to = generateUrl(patternGraphql, {}, props.query, props.origin ?? originGraphql);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectGraphql;

--- a/sample/output-with-origins/server/routes/graphql/generateUrlGraphql.ts
+++ b/sample/output-with-origins/server/routes/graphql/generateUrlGraphql.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternGraphql, UrlPartsGraphql, originGraphql } from "./patternGraphql";
 const generateUrlGraphql = (urlParts?: UrlPartsGraphql): string =>
-  generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+  generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
 export default generateUrlGraphql;

--- a/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
+++ b/sample/output-with-origins/server/routes/graphql/patternGraphql.ts
@@ -3,6 +3,6 @@ export const patternGraphql = "/graphql";
 export const originGraphql = "https://api.domain.com";
 
 export interface UrlPartsGraphql {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/graphql/useRedirectGraphql.ts
+++ b/sample/output-with-origins/server/routes/graphql/useRedirectGraphql.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnGraphql = (urlParts?: UrlPartsGraphql) => void;
 const useRedirectGraphql = (): RedirectFnGraphql => {
   const redirect: RedirectFnGraphql = (urlParts) => {
-    const to = generateUrl(patternGraphql, {}, urlParts?.urlQuery, urlParts?.origin ?? originGraphql);
+    const to = generateUrl(patternGraphql, {}, urlParts?.query, urlParts?.origin ?? originGraphql);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/home/LinkHome.tsx
+++ b/sample/output-with-origins/server/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output-with-origins/server/routes/home/RedirectHome.tsx
+++ b/sample/output-with-origins/server/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output-with-origins/server/routes/home/generateUrlHome.ts
+++ b/sample/output-with-origins/server/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output-with-origins/server/routes/home/patternHome.ts
+++ b/sample/output-with-origins/server/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "https://domain.com";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/home/useRedirectHome.ts
+++ b/sample/output-with-origins/server/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/legacy/LinkLegacy.tsx
+++ b/sample/output-with-origins/server/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output-with-origins/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output-with-origins/server/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output-with-origins/server/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "https://legacy.domain.com";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output-with-origins/server/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/terms/LinkTerms.tsx
+++ b/sample/output-with-origins/server/routes/terms/LinkTerms.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternTerms, UrlPartsTerms, originTerms } from "./patternTerms";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsTerms;
-const LinkTerms: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternTerms, {}, urlQuery, origin ?? originTerms);
+const LinkTerms: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternTerms, {}, query, origin ?? originTerms);
   return <a {...props} href={to} />;
 };
 export default LinkTerms;

--- a/sample/output-with-origins/server/routes/terms/RedirectTerms.tsx
+++ b/sample/output-with-origins/server/routes/terms/RedirectTerms.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsTerms, patternTerms, originTerms } from "./patternTerms";
 const RedirectTerms: React.FunctionComponent<UrlPartsTerms & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternTerms, {}, props.urlQuery, props.origin ?? originTerms);
+  const to = generateUrl(patternTerms, {}, props.query, props.origin ?? originTerms);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectTerms;

--- a/sample/output-with-origins/server/routes/terms/generateUrlTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/generateUrlTerms.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternTerms, UrlPartsTerms, originTerms } from "./patternTerms";
 const generateUrlTerms = (urlParts?: UrlPartsTerms): string =>
-  generateUrl(patternTerms, {}, urlParts?.urlQuery, urlParts?.origin ?? originTerms);
+  generateUrl(patternTerms, {}, urlParts?.query, urlParts?.origin ?? originTerms);
 export default generateUrlTerms;

--- a/sample/output-with-origins/server/routes/terms/patternTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/patternTerms.ts
@@ -3,6 +3,6 @@ export const patternTerms = "/terms";
 export const originTerms = "https://domain.com";
 
 export interface UrlPartsTerms {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/terms/useRedirectTerms.ts
+++ b/sample/output-with-origins/server/routes/terms/useRedirectTerms.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnTerms = (urlParts?: UrlPartsTerms) => void;
 const useRedirectTerms = (): RedirectFnTerms => {
   const redirect: RedirectFnTerms = (urlParts) => {
-    const to = generateUrl(patternTerms, {}, urlParts?.urlQuery, urlParts?.origin ?? originTerms);
+    const to = generateUrl(patternTerms, {}, urlParts?.query, urlParts?.origin ?? originTerms);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output-with-origins/server/routes/user/LinkUser.tsx
+++ b/sample/output-with-origins/server/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output-with-origins/server/routes/user/RedirectUser.tsx
+++ b/sample/output-with-origins/server/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output-with-origins/server/routes/user/generateUrlUser.ts
+++ b/sample/output-with-origins/server/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output-with-origins/server/routes/user/patternUser.ts
+++ b/sample/output-with-origins/server/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output-with-origins/server/routes/user/useRedirectUser.ts
+++ b/sample/output-with-origins/server/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/about/LinkAbout.tsx
+++ b/sample/output/app/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery, origin ?? originAbout);
+const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, query, origin ?? originAbout);
   return <a {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/app/routes/about/RedirectAbout.tsx
+++ b/sample/output/app/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout, originAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin ?? originAbout);
+  const to = generateUrl(patternAbout, props.path, props.query, props.origin ?? originAbout);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/app/routes/about/generateUrlAbout.ts
+++ b/sample/output/app/routes/about/generateUrlAbout.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
-  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+  generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
 export default generateUrlAbout;

--- a/sample/output/app/routes/about/patternAbout.ts
+++ b/sample/output/app/routes/about/patternAbout.ts
@@ -7,6 +7,6 @@ export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {
   path: PathParamsAbout;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/about/useRedirectAbout.ts
+++ b/sample/output/app/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/account/LinkAccount.tsx
+++ b/sample/output/app/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternAccount, UrlPartsAccount } from "./patternAccount";
 type LinkAccountProps = Omit<LinkProps, "to"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery, origin);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, query, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkAccount;

--- a/sample/output/app/routes/account/RedirectAccount.tsx
+++ b/sample/output/app/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsAccount, patternAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin);
+  const to = generateUrl(patternAccount, {}, props.query, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/app/routes/account/generateUrlAccount.ts
+++ b/sample/output/app/routes/account/generateUrlAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts?: UrlPartsAccount): string =>
-  generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+  generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
 export default generateUrlAccount;

--- a/sample/output/app/routes/account/patternAccount.ts
+++ b/sample/output/app/routes/account/patternAccount.ts
@@ -3,6 +3,6 @@ export const patternAccount = "/app/account";
 export const originAccount = "";
 
 export interface UrlPartsAccount {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/account/useRedirectAccount.ts
+++ b/sample/output/app/routes/account/useRedirectAccount.ts
@@ -6,7 +6,7 @@ export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const history = useHistory();
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin);
+    const to = generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin);
     history.push(to);
   };
   return redirect;

--- a/sample/output/app/routes/home/LinkHome.tsx
+++ b/sample/output/app/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/app/routes/home/RedirectHome.tsx
+++ b/sample/output/app/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/app/routes/home/generateUrlHome.ts
+++ b/sample/output/app/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output/app/routes/home/patternHome.ts
+++ b/sample/output/app/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/home/useRedirectHome.ts
+++ b/sample/output/app/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/app/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/app/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/app/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/app/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output/app/routes/legacy/patternLegacy.ts
+++ b/sample/output/app/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/app/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/login/LinkLogin.tsx
+++ b/sample/output/app/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/app/routes/login/RedirectLogin.tsx
+++ b/sample/output/app/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin, originLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin ?? originLogin);
+  const to = generateUrl(patternLogin, {}, props.query, props.origin ?? originLogin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/app/routes/login/generateUrlLogin.ts
+++ b/sample/output/app/routes/login/generateUrlLogin.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts?: UrlPartsLogin): string =>
-  generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+  generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
 export default generateUrlLogin;

--- a/sample/output/app/routes/login/patternLogin.ts
+++ b/sample/output/app/routes/login/patternLogin.ts
@@ -3,6 +3,6 @@ export const patternLogin = "/login";
 export const originLogin = "";
 
 export interface UrlPartsLogin {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/login/useRedirectLogin.ts
+++ b/sample/output/app/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+    const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/signup/LinkSignup.tsx
+++ b/sample/output/app/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery, origin ?? originSignup);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, query, origin ?? originSignup);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/app/routes/signup/RedirectSignup.tsx
+++ b/sample/output/app/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup, originSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin ?? originSignup);
+  const to = generateUrl(patternSignup, {}, props.query, props.origin ?? originSignup);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/app/routes/signup/generateUrlSignup.ts
+++ b/sample/output/app/routes/signup/generateUrlSignup.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts?: UrlPartsSignup): string =>
-  generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+  generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
 export default generateUrlSignup;

--- a/sample/output/app/routes/signup/patternSignup.ts
+++ b/sample/output/app/routes/signup/patternSignup.ts
@@ -3,6 +3,6 @@ export const patternSignup = "/signup";
 export const originSignup = "";
 
 export interface UrlPartsSignup {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/signup/useRedirectSignup.ts
+++ b/sample/output/app/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+    const to = generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/toc/LinkToc.tsx
+++ b/sample/output/app/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery, origin ?? originToc);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, query, origin ?? originToc);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/app/routes/toc/RedirectToc.tsx
+++ b/sample/output/app/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc, originToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin ?? originToc);
+  const to = generateUrl(patternToc, {}, props.query, props.origin ?? originToc);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/app/routes/toc/generateUrlToc.ts
+++ b/sample/output/app/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
 export default generateUrlToc;

--- a/sample/output/app/routes/toc/patternToc.ts
+++ b/sample/output/app/routes/toc/patternToc.ts
@@ -3,6 +3,6 @@ export const patternToc = "/terms-and-conditions";
 export const originToc = "";
 
 export interface UrlPartsToc {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/toc/useRedirectToc.ts
+++ b/sample/output/app/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+    const to = generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/app/routes/user/LinkUser.tsx
+++ b/sample/output/app/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlPartsUser } from "./patternUser";
 type LinkUserProps = Omit<LinkProps, "to"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkUser;

--- a/sample/output/app/routes/user/RedirectUser.tsx
+++ b/sample/output/app/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsUser, patternUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/app/routes/user/generateUrlUser.ts
+++ b/sample/output/app/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output/app/routes/user/patternUser.ts
+++ b/sample/output/app/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/app/routes/user/useRedirectUser.ts
+++ b/sample/output/app/routes/user/useRedirectUser.ts
@@ -6,7 +6,7 @@ export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const history = useHistory();
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin);
     history.push(to);
   };
   return redirect;

--- a/sample/output/auth/routes/about/LinkAbout.tsx
+++ b/sample/output/auth/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery, origin ?? originAbout);
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, query, origin ?? originAbout);
   return <Link {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/auth/routes/about/RedirectAbout.tsx
+++ b/sample/output/auth/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout, originAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin ?? originAbout);
+  const to = generateUrl(patternAbout, props.path, props.query, props.origin ?? originAbout);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/auth/routes/about/generateUrlAbout.ts
+++ b/sample/output/auth/routes/about/generateUrlAbout.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
-  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+  generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
 export default generateUrlAbout;

--- a/sample/output/auth/routes/about/patternAbout.ts
+++ b/sample/output/auth/routes/about/patternAbout.ts
@@ -7,6 +7,6 @@ export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {
   path: PathParamsAbout;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/about/useRedirectAbout.ts
+++ b/sample/output/auth/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/account/LinkAccount.tsx
+++ b/sample/output/auth/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery, origin ?? originAccount);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, query, origin ?? originAccount);
   return <Link {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/auth/routes/account/RedirectAccount.tsx
+++ b/sample/output/auth/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount, originAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin ?? originAccount);
+  const to = generateUrl(patternAccount, {}, props.query, props.origin ?? originAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/auth/routes/account/generateUrlAccount.ts
+++ b/sample/output/auth/routes/account/generateUrlAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts?: UrlPartsAccount): string =>
-  generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+  generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
 export default generateUrlAccount;

--- a/sample/output/auth/routes/account/patternAccount.ts
+++ b/sample/output/auth/routes/account/patternAccount.ts
@@ -3,6 +3,6 @@ export const patternAccount = "/app/account";
 export const originAccount = "";
 
 export interface UrlPartsAccount {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/account/useRedirectAccount.ts
+++ b/sample/output/auth/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+    const to = generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/home/LinkHome.tsx
+++ b/sample/output/auth/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <Link {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/auth/routes/home/RedirectHome.tsx
+++ b/sample/output/auth/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/auth/routes/home/generateUrlHome.ts
+++ b/sample/output/auth/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output/auth/routes/home/patternHome.ts
+++ b/sample/output/auth/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/home/useRedirectHome.ts
+++ b/sample/output/auth/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/auth/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <Link {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/auth/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/auth/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/auth/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/auth/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output/auth/routes/legacy/patternLegacy.ts
+++ b/sample/output/auth/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/auth/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/login/LinkLogin.tsx
+++ b/sample/output/auth/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternLogin, UrlPartsLogin } from "./patternLogin";
 type LinkLoginProps = Omit<LinkProps, "to"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery, origin);
+const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, query, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkLogin;

--- a/sample/output/auth/routes/login/RedirectLogin.tsx
+++ b/sample/output/auth/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsLogin, patternLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
+  const to = generateUrl(patternLogin, {}, props.query, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/auth/routes/login/generateUrlLogin.ts
+++ b/sample/output/auth/routes/login/generateUrlLogin.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts?: UrlPartsLogin): string =>
-  generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+  generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
 export default generateUrlLogin;

--- a/sample/output/auth/routes/login/patternLogin.ts
+++ b/sample/output/auth/routes/login/patternLogin.ts
@@ -3,6 +3,6 @@ export const patternLogin = "/login";
 export const originLogin = "";
 
 export interface UrlPartsLogin {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/signup/LinkSignup.tsx
+++ b/sample/output/auth/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { LinkProps } from "common/components/Link";
 import { patternSignup, UrlPartsSignup } from "./patternSignup";
 type LinkSignupProps = Omit<LinkProps, "to"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery, origin);
+const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, query, origin);
   return <Link {...props} to={to} />;
 };
 export default LinkSignup;

--- a/sample/output/auth/routes/signup/RedirectSignup.tsx
+++ b/sample/output/auth/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 import { Redirect } from "react-router";
 import { UrlPartsSignup, patternSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin);
+  const to = generateUrl(patternSignup, {}, props.query, props.origin);
   return (
     <>
       <Redirect to={to} />

--- a/sample/output/auth/routes/signup/generateUrlSignup.ts
+++ b/sample/output/auth/routes/signup/generateUrlSignup.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts?: UrlPartsSignup): string =>
-  generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+  generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
 export default generateUrlSignup;

--- a/sample/output/auth/routes/signup/patternSignup.ts
+++ b/sample/output/auth/routes/signup/patternSignup.ts
@@ -3,6 +3,6 @@ export const patternSignup = "/signup";
 export const originSignup = "";
 
 export interface UrlPartsSignup {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/toc/LinkToc.tsx
+++ b/sample/output/auth/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
 type LinkTocProps = Omit<AnchorProps, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery, origin ?? originToc);
+const LinkToc: React.FunctionComponent<LinkTocProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, query, origin ?? originToc);
   return <Link {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/auth/routes/toc/RedirectToc.tsx
+++ b/sample/output/auth/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc, originToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin ?? originToc);
+  const to = generateUrl(patternToc, {}, props.query, props.origin ?? originToc);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/auth/routes/toc/generateUrlToc.ts
+++ b/sample/output/auth/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
 export default generateUrlToc;

--- a/sample/output/auth/routes/toc/patternToc.ts
+++ b/sample/output/auth/routes/toc/patternToc.ts
@@ -3,6 +3,6 @@ export const patternToc = "/terms-and-conditions";
 export const originToc = "";
 
 export interface UrlPartsToc {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/toc/useRedirectToc.ts
+++ b/sample/output/auth/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+    const to = generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/auth/routes/user/LinkUser.tsx
+++ b/sample/output/auth/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <Link {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/auth/routes/user/RedirectUser.tsx
+++ b/sample/output/auth/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/auth/routes/user/generateUrlUser.ts
+++ b/sample/output/auth/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output/auth/routes/user/patternUser.ts
+++ b/sample/output/auth/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/auth/routes/user/useRedirectUser.ts
+++ b/sample/output/auth/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/about/LinkAbout.tsx
+++ b/sample/output/seo/routes/about/LinkAbout.tsx
@@ -4,7 +4,7 @@ import Link, { LinkProps } from "next/link";
 import { UrlPartsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
 type LinkAboutProps = Omit<LinkProps, "href"> & UrlPartsAbout;
 const LinkAbout: React.FunctionComponent<LinkAboutProps> = (props) => {
-  const { path = {}, urlQuery = {}, ...rest } = props;
+  const { path = {}, query = {}, ...rest } = props;
   const pathname = possilePathParamsAbout
     .filter((key) => !(key in path))
     .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);
@@ -12,7 +12,7 @@ const LinkAbout: React.FunctionComponent<LinkAboutProps> = (props) => {
     pathname: pathname,
     query: {
       ...path,
-      ...urlQuery,
+      ...query,
     },
   };
   return <Link {...rest} href={nextHref} />;

--- a/sample/output/seo/routes/about/generateUrlAbout.ts
+++ b/sample/output/seo/routes/about/generateUrlAbout.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
-  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+  generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
 export default generateUrlAbout;

--- a/sample/output/seo/routes/about/patternAbout.ts
+++ b/sample/output/seo/routes/about/patternAbout.ts
@@ -12,6 +12,6 @@ export interface PathParamsNextJSAbout {
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {
   path: PathParamsAbout;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/about/useRedirectAbout.ts
+++ b/sample/output/seo/routes/about/useRedirectAbout.ts
@@ -5,7 +5,7 @@ export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const router = useRouter();
   const redirect: RedirectFnAbout = (urlParts) => {
-    const query = urlParts?.urlQuery ?? {};
+    const query = urlParts?.query ?? {};
     const path = urlParts.path;
     const pathname = possilePathParamsAbout
       .filter((key) => !(key in urlParts.path))

--- a/sample/output/seo/routes/account/LinkAccount.tsx
+++ b/sample/output/seo/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery, origin ?? originAccount);
+const LinkAccount: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, query, origin ?? originAccount);
   return <a {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/seo/routes/account/RedirectAccount.tsx
+++ b/sample/output/seo/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount, originAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin ?? originAccount);
+  const to = generateUrl(patternAccount, {}, props.query, props.origin ?? originAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/seo/routes/account/generateUrlAccount.ts
+++ b/sample/output/seo/routes/account/generateUrlAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts?: UrlPartsAccount): string =>
-  generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+  generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
 export default generateUrlAccount;

--- a/sample/output/seo/routes/account/patternAccount.ts
+++ b/sample/output/seo/routes/account/patternAccount.ts
@@ -3,6 +3,6 @@ export const patternAccount = "/app/account";
 export const originAccount = "";
 
 export interface UrlPartsAccount {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/account/useRedirectAccount.ts
+++ b/sample/output/seo/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+    const to = generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/home/LinkHome.tsx
+++ b/sample/output/seo/routes/home/LinkHome.tsx
@@ -4,14 +4,14 @@ import Link, { LinkProps } from "next/link";
 import { UrlPartsHome, patternNextJSHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & UrlPartsHome;
 const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
-  const { urlQuery = {}, ...rest } = props;
+  const { query = {}, ...rest } = props;
   const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
     pathname: pathname,
     query: {
       ...path,
-      ...urlQuery,
+      ...query,
     },
   };
   return <Link {...rest} href={nextHref} />;

--- a/sample/output/seo/routes/home/generateUrlHome.ts
+++ b/sample/output/seo/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output/seo/routes/home/patternHome.ts
+++ b/sample/output/seo/routes/home/patternHome.ts
@@ -4,6 +4,6 @@ export const originHome = "";
 export const patternNextJSHome = "/";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/home/useRedirectHome.ts
+++ b/sample/output/seo/routes/home/useRedirectHome.ts
@@ -5,7 +5,7 @@ export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const router = useRouter();
   const redirect: RedirectFnHome = (urlParts) => {
-    const query = urlParts?.urlQuery ?? {};
+    const query = urlParts?.query ?? {};
     const path = {};
     const pathname = patternNextJSHome;
     router.push({

--- a/sample/output/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/seo/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/seo/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/seo/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/seo/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output/seo/routes/legacy/patternLegacy.ts
+++ b/sample/output/seo/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/seo/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/login/LinkLogin.tsx
+++ b/sample/output/seo/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/seo/routes/login/RedirectLogin.tsx
+++ b/sample/output/seo/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin, originLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin ?? originLogin);
+  const to = generateUrl(patternLogin, {}, props.query, props.origin ?? originLogin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/seo/routes/login/generateUrlLogin.ts
+++ b/sample/output/seo/routes/login/generateUrlLogin.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts?: UrlPartsLogin): string =>
-  generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+  generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
 export default generateUrlLogin;

--- a/sample/output/seo/routes/login/patternLogin.ts
+++ b/sample/output/seo/routes/login/patternLogin.ts
@@ -3,6 +3,6 @@ export const patternLogin = "/login";
 export const originLogin = "";
 
 export interface UrlPartsLogin {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/login/useRedirectLogin.ts
+++ b/sample/output/seo/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+    const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/signup/LinkSignup.tsx
+++ b/sample/output/seo/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery, origin ?? originSignup);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, query, origin ?? originSignup);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/seo/routes/signup/RedirectSignup.tsx
+++ b/sample/output/seo/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup, originSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin ?? originSignup);
+  const to = generateUrl(patternSignup, {}, props.query, props.origin ?? originSignup);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/seo/routes/signup/generateUrlSignup.ts
+++ b/sample/output/seo/routes/signup/generateUrlSignup.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts?: UrlPartsSignup): string =>
-  generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+  generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
 export default generateUrlSignup;

--- a/sample/output/seo/routes/signup/patternSignup.ts
+++ b/sample/output/seo/routes/signup/patternSignup.ts
@@ -3,6 +3,6 @@ export const patternSignup = "/signup";
 export const originSignup = "";
 
 export interface UrlPartsSignup {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/signup/useRedirectSignup.ts
+++ b/sample/output/seo/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+    const to = generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/toc/LinkToc.tsx
+++ b/sample/output/seo/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery, origin ?? originToc);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, query, origin ?? originToc);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/seo/routes/toc/RedirectToc.tsx
+++ b/sample/output/seo/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc, originToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin ?? originToc);
+  const to = generateUrl(patternToc, {}, props.query, props.origin ?? originToc);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/seo/routes/toc/generateUrlToc.ts
+++ b/sample/output/seo/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
 export default generateUrlToc;

--- a/sample/output/seo/routes/toc/patternToc.ts
+++ b/sample/output/seo/routes/toc/patternToc.ts
@@ -3,6 +3,6 @@ export const patternToc = "/terms-and-conditions";
 export const originToc = "";
 
 export interface UrlPartsToc {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/toc/useRedirectToc.ts
+++ b/sample/output/seo/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+    const to = generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/seo/routes/user/LinkUser.tsx
+++ b/sample/output/seo/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/seo/routes/user/RedirectUser.tsx
+++ b/sample/output/seo/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/seo/routes/user/generateUrlUser.ts
+++ b/sample/output/seo/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output/seo/routes/user/patternUser.ts
+++ b/sample/output/seo/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/seo/routes/user/useRedirectUser.ts
+++ b/sample/output/seo/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/about/LinkAbout.tsx
+++ b/sample/output/server/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery, origin ?? originAbout);
+const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, query, origin ?? originAbout);
   return <a {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/server/routes/about/RedirectAbout.tsx
+++ b/sample/output/server/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout, originAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin ?? originAbout);
+  const to = generateUrl(patternAbout, props.path, props.query, props.origin ?? originAbout);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/server/routes/about/generateUrlAbout.ts
+++ b/sample/output/server/routes/about/generateUrlAbout.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
-  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+  generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
 export default generateUrlAbout;

--- a/sample/output/server/routes/about/patternAbout.ts
+++ b/sample/output/server/routes/about/patternAbout.ts
@@ -7,6 +7,6 @@ export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {
   path: PathParamsAbout;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/about/useRedirectAbout.ts
+++ b/sample/output/server/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/account/LinkAccount.tsx
+++ b/sample/output/server/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery, origin ?? originAccount);
+const LinkAccount: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, query, origin ?? originAccount);
   return <a {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/server/routes/account/RedirectAccount.tsx
+++ b/sample/output/server/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount, originAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin ?? originAccount);
+  const to = generateUrl(patternAccount, {}, props.query, props.origin ?? originAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/server/routes/account/generateUrlAccount.ts
+++ b/sample/output/server/routes/account/generateUrlAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts?: UrlPartsAccount): string =>
-  generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+  generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
 export default generateUrlAccount;

--- a/sample/output/server/routes/account/patternAccount.ts
+++ b/sample/output/server/routes/account/patternAccount.ts
@@ -3,6 +3,6 @@ export const patternAccount = "/app/account";
 export const originAccount = "";
 
 export interface UrlPartsAccount {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/account/useRedirectAccount.ts
+++ b/sample/output/server/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+    const to = generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/home/LinkHome.tsx
+++ b/sample/output/server/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <a {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/server/routes/home/RedirectHome.tsx
+++ b/sample/output/server/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/server/routes/home/generateUrlHome.ts
+++ b/sample/output/server/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output/server/routes/home/patternHome.ts
+++ b/sample/output/server/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/home/useRedirectHome.ts
+++ b/sample/output/server/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/server/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <a {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/server/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/server/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/server/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output/server/routes/legacy/patternLegacy.ts
+++ b/sample/output/server/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/server/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/login/LinkLogin.tsx
+++ b/sample/output/server/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
   return <a {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/server/routes/login/RedirectLogin.tsx
+++ b/sample/output/server/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin, originLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin ?? originLogin);
+  const to = generateUrl(patternLogin, {}, props.query, props.origin ?? originLogin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/server/routes/login/generateUrlLogin.ts
+++ b/sample/output/server/routes/login/generateUrlLogin.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts?: UrlPartsLogin): string =>
-  generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+  generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
 export default generateUrlLogin;

--- a/sample/output/server/routes/login/patternLogin.ts
+++ b/sample/output/server/routes/login/patternLogin.ts
@@ -3,6 +3,6 @@ export const patternLogin = "/login";
 export const originLogin = "";
 
 export interface UrlPartsLogin {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/login/useRedirectLogin.ts
+++ b/sample/output/server/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+    const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/signup/LinkSignup.tsx
+++ b/sample/output/server/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery, origin ?? originSignup);
+const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, query, origin ?? originSignup);
   return <a {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/server/routes/signup/RedirectSignup.tsx
+++ b/sample/output/server/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup, originSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin ?? originSignup);
+  const to = generateUrl(patternSignup, {}, props.query, props.origin ?? originSignup);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/server/routes/signup/generateUrlSignup.ts
+++ b/sample/output/server/routes/signup/generateUrlSignup.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts?: UrlPartsSignup): string =>
-  generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+  generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
 export default generateUrlSignup;

--- a/sample/output/server/routes/signup/patternSignup.ts
+++ b/sample/output/server/routes/signup/patternSignup.ts
@@ -3,6 +3,6 @@ export const patternSignup = "/signup";
 export const originSignup = "";
 
 export interface UrlPartsSignup {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/signup/useRedirectSignup.ts
+++ b/sample/output/server/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+    const to = generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/toc/LinkToc.tsx
+++ b/sample/output/server/routes/toc/LinkToc.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsToc;
-const LinkToc: React.FunctionComponent<LinkProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternToc, {}, urlQuery, origin ?? originToc);
+const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternToc, {}, query, origin ?? originToc);
   return <a {...props} href={to} />;
 };
 export default LinkToc;

--- a/sample/output/server/routes/toc/RedirectToc.tsx
+++ b/sample/output/server/routes/toc/RedirectToc.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsToc, patternToc, originToc } from "./patternToc";
 const RedirectToc: React.FunctionComponent<UrlPartsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, {}, props.urlQuery, props.origin ?? originToc);
+  const to = generateUrl(patternToc, {}, props.query, props.origin ?? originToc);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectToc;

--- a/sample/output/server/routes/toc/generateUrlToc.ts
+++ b/sample/output/server/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
 export default generateUrlToc;

--- a/sample/output/server/routes/toc/patternToc.ts
+++ b/sample/output/server/routes/toc/patternToc.ts
@@ -3,6 +3,6 @@ export const patternToc = "/terms-and-conditions";
 export const originToc = "";
 
 export interface UrlPartsToc {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/toc/useRedirectToc.ts
+++ b/sample/output/server/routes/toc/useRedirectToc.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const redirect: RedirectFnToc = (urlParts) => {
-    const to = generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+    const to = generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/server/routes/user/LinkUser.tsx
+++ b/sample/output/server/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <a {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/server/routes/user/RedirectUser.tsx
+++ b/sample/output/server/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/server/routes/user/generateUrlUser.ts
+++ b/sample/output/server/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output/server/routes/user/patternUser.ts
+++ b/sample/output/server/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/server/routes/user/useRedirectUser.ts
+++ b/sample/output/server/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/about/LinkAbout.tsx
+++ b/sample/output/toc/routes/about/LinkAbout.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 type LinkAboutProps = Omit<AnchorProps, "href"> & UrlPartsAbout;
-const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAbout, path, urlQuery, origin ?? originAbout);
+const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternAbout, path, query, origin ?? originAbout);
   return <Link {...props} href={to} />;
 };
 export default LinkAbout;

--- a/sample/output/toc/routes/about/RedirectAbout.tsx
+++ b/sample/output/toc/routes/about/RedirectAbout.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAbout, patternAbout, originAbout } from "./patternAbout";
 const RedirectAbout: React.FunctionComponent<UrlPartsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, props.path, props.urlQuery, props.origin ?? originAbout);
+  const to = generateUrl(patternAbout, props.path, props.query, props.origin ?? originAbout);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAbout;

--- a/sample/output/toc/routes/about/generateUrlAbout.ts
+++ b/sample/output/toc/routes/about/generateUrlAbout.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAbout, UrlPartsAbout, originAbout } from "./patternAbout";
 const generateUrlAbout = (urlParts: UrlPartsAbout): string =>
-  generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+  generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
 export default generateUrlAbout;

--- a/sample/output/toc/routes/about/patternAbout.ts
+++ b/sample/output/toc/routes/about/patternAbout.ts
@@ -7,6 +7,6 @@ export type PathParamsAbout = { target: "us" | "you"; topic: string; optional?: 
 export const possilePathParamsAbout = ["target", "topic", "optional", "optionalEnum"];
 export interface UrlPartsAbout {
   path: PathParamsAbout;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/about/useRedirectAbout.ts
+++ b/sample/output/toc/routes/about/useRedirectAbout.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAbout = (urlParts: UrlPartsAbout) => void;
 const useRedirectAbout = (): RedirectFnAbout => {
   const redirect: RedirectFnAbout = (urlParts) => {
-    const to = generateUrl(patternAbout, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originAbout);
+    const to = generateUrl(patternAbout, urlParts.path, urlParts?.query, urlParts?.origin ?? originAbout);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/account/LinkAccount.tsx
+++ b/sample/output/toc/routes/account/LinkAccount.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 type LinkAccountProps = Omit<AnchorProps, "href"> & UrlPartsAccount;
-const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternAccount, {}, urlQuery, origin ?? originAccount);
+const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternAccount, {}, query, origin ?? originAccount);
   return <Link {...props} href={to} />;
 };
 export default LinkAccount;

--- a/sample/output/toc/routes/account/RedirectAccount.tsx
+++ b/sample/output/toc/routes/account/RedirectAccount.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsAccount, patternAccount, originAccount } from "./patternAccount";
 const RedirectAccount: React.FunctionComponent<UrlPartsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, {}, props.urlQuery, props.origin ?? originAccount);
+  const to = generateUrl(patternAccount, {}, props.query, props.origin ?? originAccount);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectAccount;

--- a/sample/output/toc/routes/account/generateUrlAccount.ts
+++ b/sample/output/toc/routes/account/generateUrlAccount.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternAccount, UrlPartsAccount, originAccount } from "./patternAccount";
 const generateUrlAccount = (urlParts?: UrlPartsAccount): string =>
-  generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+  generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
 export default generateUrlAccount;

--- a/sample/output/toc/routes/account/patternAccount.ts
+++ b/sample/output/toc/routes/account/patternAccount.ts
@@ -3,6 +3,6 @@ export const patternAccount = "/app/account";
 export const originAccount = "";
 
 export interface UrlPartsAccount {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/account/useRedirectAccount.ts
+++ b/sample/output/toc/routes/account/useRedirectAccount.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnAccount = (urlParts?: UrlPartsAccount) => void;
 const useRedirectAccount = (): RedirectFnAccount => {
   const redirect: RedirectFnAccount = (urlParts) => {
-    const to = generateUrl(patternAccount, {}, urlParts?.urlQuery, urlParts?.origin ?? originAccount);
+    const to = generateUrl(patternAccount, {}, urlParts?.query, urlParts?.origin ?? originAccount);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/home/LinkHome.tsx
+++ b/sample/output/toc/routes/home/LinkHome.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
 type LinkHomeProps = Omit<AnchorProps, "href"> & UrlPartsHome;
-const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternHome, {}, urlQuery, origin ?? originHome);
+const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternHome, {}, query, origin ?? originHome);
   return <Link {...props} href={to} />;
 };
 export default LinkHome;

--- a/sample/output/toc/routes/home/RedirectHome.tsx
+++ b/sample/output/toc/routes/home/RedirectHome.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsHome, patternHome, originHome } from "./patternHome";
 const RedirectHome: React.FunctionComponent<UrlPartsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, {}, props.urlQuery, props.origin ?? originHome);
+  const to = generateUrl(patternHome, {}, props.query, props.origin ?? originHome);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectHome;

--- a/sample/output/toc/routes/home/generateUrlHome.ts
+++ b/sample/output/toc/routes/home/generateUrlHome.ts
@@ -1,6 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternHome, UrlPartsHome, originHome } from "./patternHome";
-const generateUrlHome = (urlParts?: UrlPartsHome): string =>
-  generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+const generateUrlHome = (urlParts?: UrlPartsHome): string => generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
 export default generateUrlHome;

--- a/sample/output/toc/routes/home/patternHome.ts
+++ b/sample/output/toc/routes/home/patternHome.ts
@@ -3,6 +3,6 @@ export const patternHome = "/";
 export const originHome = "";
 
 export interface UrlPartsHome {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/home/useRedirectHome.ts
+++ b/sample/output/toc/routes/home/useRedirectHome.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnHome = (urlParts?: UrlPartsHome) => void;
 const useRedirectHome = (): RedirectFnHome => {
   const redirect: RedirectFnHome = (urlParts) => {
-    const to = generateUrl(patternHome, {}, urlParts?.urlQuery, urlParts?.origin ?? originHome);
+    const to = generateUrl(patternHome, {}, urlParts?.query, urlParts?.origin ?? originHome);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/legacy/LinkLegacy.tsx
+++ b/sample/output/toc/routes/legacy/LinkLegacy.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlPartsLegacy;
-const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, {}, urlQuery, origin ?? originLegacy);
+const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLegacy, {}, query, origin ?? originLegacy);
   return <Link {...props} href={to} />;
 };
 export default LinkLegacy;

--- a/sample/output/toc/routes/legacy/RedirectLegacy.tsx
+++ b/sample/output/toc/routes/legacy/RedirectLegacy.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
 const RedirectLegacy: React.FunctionComponent<UrlPartsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, {}, props.urlQuery, props.origin ?? originLegacy);
+  const to = generateUrl(patternLegacy, {}, props.query, props.origin ?? originLegacy);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLegacy;

--- a/sample/output/toc/routes/legacy/generateUrlLegacy.ts
+++ b/sample/output/toc/routes/legacy/generateUrlLegacy.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLegacy, UrlPartsLegacy, originLegacy } from "./patternLegacy";
 const generateUrlLegacy = (urlParts?: UrlPartsLegacy): string =>
-  generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+  generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
 export default generateUrlLegacy;

--- a/sample/output/toc/routes/legacy/patternLegacy.ts
+++ b/sample/output/toc/routes/legacy/patternLegacy.ts
@@ -3,6 +3,6 @@ export const patternLegacy = "/legacy/app";
 export const originLegacy = "";
 
 export interface UrlPartsLegacy {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/legacy/useRedirectLegacy.ts
+++ b/sample/output/toc/routes/legacy/useRedirectLegacy.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLegacy = (urlParts?: UrlPartsLegacy) => void;
 const useRedirectLegacy = (): RedirectFnLegacy => {
   const redirect: RedirectFnLegacy = (urlParts) => {
-    const to = generateUrl(patternLegacy, {}, urlParts?.urlQuery, urlParts?.origin ?? originLegacy);
+    const to = generateUrl(patternLegacy, {}, urlParts?.query, urlParts?.origin ?? originLegacy);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/login/LinkLogin.tsx
+++ b/sample/output/toc/routes/login/LinkLogin.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 type LinkLoginProps = Omit<AnchorProps, "href"> & UrlPartsLogin;
-const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
   return <Link {...props} href={to} />;
 };
 export default LinkLogin;

--- a/sample/output/toc/routes/login/RedirectLogin.tsx
+++ b/sample/output/toc/routes/login/RedirectLogin.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsLogin, patternLogin, originLogin } from "./patternLogin";
 const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin ?? originLogin);
+  const to = generateUrl(patternLogin, {}, props.query, props.origin ?? originLogin);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectLogin;

--- a/sample/output/toc/routes/login/generateUrlLogin.ts
+++ b/sample/output/toc/routes/login/generateUrlLogin.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternLogin, UrlPartsLogin, originLogin } from "./patternLogin";
 const generateUrlLogin = (urlParts?: UrlPartsLogin): string =>
-  generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+  generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
 export default generateUrlLogin;

--- a/sample/output/toc/routes/login/patternLogin.ts
+++ b/sample/output/toc/routes/login/patternLogin.ts
@@ -3,6 +3,6 @@ export const patternLogin = "/login";
 export const originLogin = "";
 
 export interface UrlPartsLogin {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/login/useRedirectLogin.ts
+++ b/sample/output/toc/routes/login/useRedirectLogin.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
 const useRedirectLogin = (): RedirectFnLogin => {
   const redirect: RedirectFnLogin = (urlParts) => {
-    const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+    const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/signup/LinkSignup.tsx
+++ b/sample/output/toc/routes/signup/LinkSignup.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 type LinkSignupProps = Omit<AnchorProps, "href"> & UrlPartsSignup;
-const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternSignup, {}, urlQuery, origin ?? originSignup);
+const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ query, origin, ...props }) => {
+  const to = generateUrl(patternSignup, {}, query, origin ?? originSignup);
   return <Link {...props} href={to} />;
 };
 export default LinkSignup;

--- a/sample/output/toc/routes/signup/RedirectSignup.tsx
+++ b/sample/output/toc/routes/signup/RedirectSignup.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsSignup, patternSignup, originSignup } from "./patternSignup";
 const RedirectSignup: React.FunctionComponent<UrlPartsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, {}, props.urlQuery, props.origin ?? originSignup);
+  const to = generateUrl(patternSignup, {}, props.query, props.origin ?? originSignup);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectSignup;

--- a/sample/output/toc/routes/signup/generateUrlSignup.ts
+++ b/sample/output/toc/routes/signup/generateUrlSignup.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternSignup, UrlPartsSignup, originSignup } from "./patternSignup";
 const generateUrlSignup = (urlParts?: UrlPartsSignup): string =>
-  generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+  generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
 export default generateUrlSignup;

--- a/sample/output/toc/routes/signup/patternSignup.ts
+++ b/sample/output/toc/routes/signup/patternSignup.ts
@@ -3,6 +3,6 @@ export const patternSignup = "/signup";
 export const originSignup = "";
 
 export interface UrlPartsSignup {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/signup/useRedirectSignup.ts
+++ b/sample/output/toc/routes/signup/useRedirectSignup.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnSignup = (urlParts?: UrlPartsSignup) => void;
 const useRedirectSignup = (): RedirectFnSignup => {
   const redirect: RedirectFnSignup = (urlParts) => {
-    const to = generateUrl(patternSignup, {}, urlParts?.urlQuery, urlParts?.origin ?? originSignup);
+    const to = generateUrl(patternSignup, {}, urlParts?.query, urlParts?.origin ?? originSignup);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/sample/output/toc/routes/toc/LinkToc.tsx
+++ b/sample/output/toc/routes/toc/LinkToc.tsx
@@ -4,14 +4,14 @@ import Link, { LinkProps } from "src/common/components/Link";
 import { UrlPartsToc, patternNextJSToc } from "./patternToc";
 type LinkTocProps = Omit<LinkProps, "href"> & UrlPartsToc;
 const LinkToc: React.FunctionComponent<LinkTocProps> = (props) => {
-  const { urlQuery = {}, ...rest } = props;
+  const { query = {}, ...rest } = props;
   const path = {};
   const pathname = patternNextJSToc;
   const nextHref = {
     pathname: pathname,
     query: {
       ...path,
-      ...urlQuery,
+      ...query,
     },
   };
   return <Link {...rest} href={nextHref} />;

--- a/sample/output/toc/routes/toc/generateUrlToc.ts
+++ b/sample/output/toc/routes/toc/generateUrlToc.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import generateUrl from "route-codegen/generateUrl";
 import { patternToc, UrlPartsToc, originToc } from "./patternToc";
-const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.urlQuery, urlParts?.origin ?? originToc);
+const generateUrlToc = (urlParts?: UrlPartsToc): string => generateUrl(patternToc, {}, urlParts?.query, urlParts?.origin ?? originToc);
 export default generateUrlToc;

--- a/sample/output/toc/routes/toc/patternToc.ts
+++ b/sample/output/toc/routes/toc/patternToc.ts
@@ -4,6 +4,6 @@ export const originToc = "";
 export const patternNextJSToc = "/terms-and-conditions";
 
 export interface UrlPartsToc {
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/toc/useRedirectToc.ts
+++ b/sample/output/toc/routes/toc/useRedirectToc.ts
@@ -5,7 +5,7 @@ export type RedirectFnToc = (urlParts?: UrlPartsToc) => void;
 const useRedirectToc = (): RedirectFnToc => {
   const router = useRouter();
   const redirect: RedirectFnToc = (urlParts) => {
-    const query = urlParts?.urlQuery ?? {};
+    const query = urlParts?.query ?? {};
     const path = {};
     const pathname = patternNextJSToc;
     router.push({

--- a/sample/output/toc/routes/user/LinkUser.tsx
+++ b/sample/output/toc/routes/user/LinkUser.tsx
@@ -4,8 +4,8 @@ import generateUrl from "route-codegen/generateUrl";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 type LinkUserProps = Omit<AnchorProps, "href"> & UrlPartsUser;
-const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, urlQuery, origin, ...props }) => {
-  const to = generateUrl(patternUser, path, urlQuery, origin ?? originUser);
+const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
+  const to = generateUrl(patternUser, path, query, origin ?? originUser);
   return <Link {...props} href={to} />;
 };
 export default LinkUser;

--- a/sample/output/toc/routes/user/RedirectUser.tsx
+++ b/sample/output/toc/routes/user/RedirectUser.tsx
@@ -4,7 +4,7 @@ import RedirectServerSide from "route-codegen/RedirectServerSide";
 import generateUrl from "route-codegen/generateUrl";
 import { UrlPartsUser, patternUser, originUser } from "./patternUser";
 const RedirectUser: React.FunctionComponent<UrlPartsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, props.path, props.urlQuery, props.origin ?? originUser);
+  const to = generateUrl(patternUser, props.path, props.query, props.origin ?? originUser);
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };
 export default RedirectUser;

--- a/sample/output/toc/routes/user/generateUrlUser.ts
+++ b/sample/output/toc/routes/user/generateUrlUser.ts
@@ -2,5 +2,5 @@
 import generateUrl from "route-codegen/generateUrl";
 import { patternUser, UrlPartsUser, originUser } from "./patternUser";
 const generateUrlUser = (urlParts: UrlPartsUser): string =>
-  generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
 export default generateUrlUser;

--- a/sample/output/toc/routes/user/patternUser.ts
+++ b/sample/output/toc/routes/user/patternUser.ts
@@ -7,6 +7,6 @@ export type PathParamsUser = { id: string; subview?: "pictures" };
 export const possilePathParamsUser = ["id", "subview"];
 export interface UrlPartsUser {
   path: PathParamsUser;
-  urlQuery?: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
   origin?: string;
 }

--- a/sample/output/toc/routes/user/useRedirectUser.ts
+++ b/sample/output/toc/routes/user/useRedirectUser.ts
@@ -4,7 +4,7 @@ import generateUrl from "route-codegen/generateUrl";
 export type RedirectFnUser = (urlParts: UrlPartsUser) => void;
 const useRedirectUser = (): RedirectFnUser => {
   const redirect: RedirectFnUser = (urlParts) => {
-    const to = generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+    const to = generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
     if (!!window && !!window.location) {
       window.location.href = to;
     }

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
@@ -45,7 +45,7 @@ describe("generatePatternFile", () => {
   export const possilePathParamsUserInfo = ['id','subview',]
   export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
-    urlQuery?: Record<string, string | undefined>;
+    query?: Record<string, string | undefined>;
     origin?: string;
   }`
       );
@@ -82,7 +82,7 @@ describe("generatePatternFile", () => {
   export const possilePathParamsUserInfo = ['id','subview','optional','optionalEnum',]
   export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
-    urlQuery?: Record<string, string | undefined>;
+    query?: Record<string, string | undefined>;
     origin?: string;
   }`);
       expect(interfaceResult).toEqual({
@@ -120,7 +120,7 @@ describe("generatePatternFile", () => {
   export const possilePathParamsUserInfo = ['id','subview',]
   export interface UrlPartsUserInfo {
     path: PathParamsUserInfo;
-    urlQuery?: Record<string, string | undefined>;
+    query?: Record<string, string | undefined>;
     origin?: string;
   }`
       );

--- a/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -158,7 +158,7 @@ const generateUrlPartsInterface = (
 
   const template = `export interface ${interfaceName} {
     ${pathParams ? `path: ${pathParams.interfaceName};` : ""}
-    urlQuery?: Record<string, string | undefined>;
+    query?: Record<string, string | undefined>;
     origin?: string;
   }`;
 

--- a/src/generate/generateAppFiles/generatorCore/generateUrlFile.test.ts
+++ b/src/generate/generateAppFiles/generatorCore/generateUrlFile.test.ts
@@ -19,7 +19,7 @@ describe("generateUseParamsFile", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,originUser,} from './patternUser'
-  const generateUrlUser = ( urlParts?: UrlPartsUser ): string => generateUrl(patternUser, {}, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  const generateUrlUser = ( urlParts?: UrlPartsUser ): string => generateUrl(patternUser, {}, urlParts?.query, urlParts?.origin ?? originUser);
   export default generateUrlUser;`);
   });
 
@@ -42,7 +42,7 @@ describe("generateUseParamsFile", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toContain(`import {generateUrl,} from 'route-codegen'
   import {patternUser,UrlPartsUser,originUser,} from './patternUser'
-  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originUser);
+  const generateUrlUser = ( urlParts: UrlPartsUser ): string => generateUrl(patternUser, urlParts.path, urlParts?.query, urlParts?.origin ?? originUser);
   export default generateUrlUser;`);
   });
 });

--- a/src/generate/generateAppFiles/generatorCore/generateUrlFile.ts
+++ b/src/generate/generateAppFiles/generatorCore/generateUrlFile.ts
@@ -24,7 +24,7 @@ const generateUrlFile: GenerateUrlFile = ({
     namedImports: [{ name: patternName }, { name: urlPartsInterfaceName }, { name: originName }],
     from: `./${filename}`,
   })}
-  const ${functionName} = ( urlParts${urlPartOptionalModifier}: ${urlPartsInterfaceName} ): string => generateUrl(${patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin ?? ${originName});
+  const ${functionName} = ( urlParts${urlPartOptionalModifier}: ${urlPartsInterfaceName} ): string => generateUrl(${patternName}, ${pathVariable}, urlParts?.query, urlParts?.origin ?? ${originName});
   export default ${functionName};
   `;
 

--- a/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
@@ -52,8 +52,8 @@ describe("generateLinkFileDefault", () => {
   import Link, {CustomLinkProps,} from 'src/Default/Link'
   import {patternLogin,UrlPartsLogin,originLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
     return <Link {...props} customDefaultHref={to} />;
   }
   export default LinkLogin;`);
@@ -70,8 +70,8 @@ describe("generateLinkFileDefault", () => {
   
   import {patternLogin,UrlPartsLogin,originLogin,} from './patternLogin'
   type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
     return <a {...props} href={to} />;
   }
   export default LinkLogin;`);
@@ -94,8 +94,8 @@ describe("generateLinkFileDefault", () => {
   
   import {patternLogin,UrlPartsLogin,originLogin,} from './patternLogin'
   type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, path, urlQuery, origin ?? originLogin);
+  const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, path, query, origin ?? originLogin);
     return <a {...props} href={to} />;
   }
   export default LinkLogin;`);
@@ -126,8 +126,8 @@ describe("generateLinkFileDefault", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,originLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery, origin ?? originLogin);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, query, origin ?? originLogin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);

--- a/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
@@ -40,8 +40,8 @@ const generateLinkFileDefault = (params: GenerateLinkFileDefaultParams): Templat
   ${linkPropsTemplate}
   const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
     hasPathParams ? "path," : ""
-  } urlQuery, origin, ...props }) => {
-    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery, origin ?? ${originName});
+  } query, origin, ...props }) => {
+    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, query, origin ?? ${originName});
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }
   export default ${functionName};

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
@@ -26,7 +26,7 @@ describe("generateRedirectFileDefault", () => {
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,originLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin ?? originLogin);
+    const to = generateUrl(patternLogin, {}, props.query, props.origin ?? originLogin);
     return <RedirectServerSide href={to} fallback={props.fallback} />;
   };
   export default RedirectLogin`);
@@ -49,7 +49,7 @@ describe("generateRedirectFileDefault", () => {
   import {generateUrl,} from 'route-codegen'
   import {UrlPartsLogin,patternLogin,originLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, props.path, props.urlQuery, props.origin ?? originLogin);
+    const to = generateUrl(patternLogin, props.path, props.query, props.origin ?? originLogin);
     return <RedirectServerSide href={to} fallback={props.fallback} />;
   };
   export default RedirectLogin`);

--- a/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
@@ -28,7 +28,7 @@ const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultParams):
     from: `./${patternNamedExports.filename}`,
   })}
   const ${functionName}: React.FunctionComponent<${patternNamedExports.urlPartsInterfaceName} & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery, props.origin ?? ${
+    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.query, props.origin ?? ${
     patternNamedExports.originName
   });
     return <${importRedirectServerSide.defaultImport} href={to} fallback={props.fallback} />;

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.test.ts
@@ -25,7 +25,7 @@ describe("generateUseRedirectFileDefault", () => {
   export type RedirectFnLogin = (urlParts?: UrlPartsLogin) => void;
   const useRedirectLogin = (): RedirectFnLogin => {
     const redirect: RedirectFnLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+      const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin ?? originLogin);
       if (!!window && !!window.location) {
         window.location.href = to;
       }
@@ -61,7 +61,7 @@ describe("generateUseRedirectFileDefault", () => {
   export type RedirectFnUserInfo = (urlParts: UrlPartsUserInfo) => void;
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const redirect: RedirectFnUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery, urlParts?.origin ?? originLogin);
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.query, urlParts?.origin ?? originLogin);
       if (!!window && !!window.location) {
         window.location.href = to;
       }

--- a/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
+++ b/src/generate/generateAppFiles/generatorDefault/generateUseRedirectFileDefault.ts
@@ -29,7 +29,7 @@ const generateUseRedirectFileDefault = (params: GenerateUseRedirectFileDefaultPa
   }) => void;
   const ${functionName} = (): ${resultTypeInterface} => {
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin ?? ${
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.query, urlParts?.origin ?? ${
     patternNamedExports.originName
   });
       if (!!window && !!window.location) {

--- a/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
@@ -39,13 +39,13 @@ describe("generateLinkFileNextJS", () => {
   import {UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-    const { urlQuery = {}, ...rest } = props; const path = {};
+    const { query = {}, ...rest } = props; const path = {};
     const pathname = patternNextJSLogin;
     const nextHref = {
       pathname: pathname,
       query: {
         ...path,
-        ...urlQuery,
+        ...query,
       },
     }
     return <Link {...rest} customHref={nextHref} />;
@@ -71,13 +71,13 @@ describe("generateLinkFileNextJS", () => {
   import {UrlPartsLogin,patternNextJSLogin,possiblePathParamsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-    const { path = {}, urlQuery = {}, ...rest } = props;
+    const { path = {}, query = {}, ...rest } = props;
     const pathname = possiblePathParamsLogin.filter((key) => !(key in path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), patternNextJSLogin);
     const nextHref = {
       pathname: pathname,
       query: {
         ...path,
-        ...urlQuery,
+        ...query,
       },
     }
     return <Link {...rest} customHref={nextHref} />;
@@ -110,13 +110,13 @@ describe("generateLinkFileNextJS", () => {
   import {UrlPartsLogin,patternNextJSLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
   const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-    const { urlQuery = {}, ...rest } = props; const path = {};
+    const { query = {}, ...rest } = props; const path = {};
     const pathname = patternNextJSLogin;
     const nextHref = {
       pathname: pathname,
       query: {
         ...path,
-        ...urlQuery,
+        ...query,
       },
     }
     return <Link {...rest} to={nextHref} />;

--- a/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.ts
@@ -48,8 +48,8 @@ const generateLinkFileNextJS = (params: GenerateLinkFileNextJSParams): TemplateF
   }
 
   const variablesTemplate = hasPathParams
-    ? `const { path = {}, urlQuery = {}, ...rest } = props;`
-    : `const { urlQuery = {}, ...rest } = props; const path = {};`;
+    ? `const { path = {}, query = {}, ...rest } = props;`
+    : `const { query = {}, ...rest } = props; const path = {};`;
 
   const template = `${printImport({ defaultImport: "React", from: "react" })}
   ${importLink ? printImport(importLink) : ""}
@@ -62,7 +62,7 @@ const generateLinkFileNextJS = (params: GenerateLinkFileNextJSParams): TemplateF
       pathname: pathname,
       query: {
         ...path,
-        ...urlQuery,
+        ...query,
       },
     }
     return <${linkComponent} {...rest} ${hrefProp}={nextHref} />;

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.test.ts
@@ -27,7 +27,7 @@ describe("generateUseRedirectFileNextJS", () => {
   const useRedirectLogin = (): RedirectFnLogin => {
     const router = useRouter();
     const redirect: RedirectFnLogin = urlParts => {
-      const query = urlParts?.urlQuery ?? {};
+      const query = urlParts?.query ?? {};
       const path = {};
       const pathname = patternNextJSLogin;
       router.push({
@@ -72,7 +72,7 @@ describe("generateUseRedirectFileNextJS", () => {
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const router = useRouter();
     const redirect: RedirectFnUserInfo = urlParts => {
-      const query = urlParts?.urlQuery ?? {};
+      const query = urlParts?.query ?? {};
       const path = urlParts.path;
       const pathname = possiblePathParamsUserInfo.filter((key) => !(key in urlParts.path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(${"`/[${suppliedParam}]`"}, \"\"), patternNextJSUserInfo);
       router.push({

--- a/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
+++ b/src/generate/generateAppFiles/generatorNextJS/generateUseRedirectFileNextJS.ts
@@ -45,7 +45,7 @@ const generateUseRedirectFileNextJS = (params: GenerateUseRedirectFileNextJSPara
   const ${functionName} = (): ${resultTypeInterface} => {
     const router = useRouter();
     const redirect: ${resultTypeInterface} = urlParts => {
-      const query = urlParts?.urlQuery ?? {};
+      const query = urlParts?.query ?? {};
       const path = ${pathVariable};
       ${pathnameTemplate}
       router.push({

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
@@ -40,8 +40,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import Link, {CustomLinkProps,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery, origin);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, query, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);
@@ -64,8 +64,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import Link, {CustomLinkProps,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, path, urlQuery, origin);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, path, query, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);
@@ -97,8 +97,8 @@ describe("generateLinkFileReactRouterV5", () => {
   import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
   import {patternLogin,UrlPartsLogin,} from './patternLogin'
   type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlPartsLogin
-  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  urlQuery, origin, ...props }) => {
-    const to = generateUrl(patternLogin, {}, urlQuery, origin);
+  const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
+    const to = generateUrl(patternLogin, {}, query, origin);
     return <Link {...props} to={to} />;
   }
   export default LinkLogin;`);

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
@@ -40,8 +40,8 @@ const generateLinkFileReactRouterV5 = (params: GenerateLinkFileReactRouterV5Para
   ${linkPropsTemplate}
   const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
     hasPathParams ? "path," : ""
-  } urlQuery, origin, ...props }) => {
-    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, urlQuery, origin);
+  } query, origin, ...props }) => {
+    const to = generateUrl(${patternName}, ${hasPathParams ? "path" : "{}"}, query, origin);
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }
   export default ${functionName};

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
@@ -25,7 +25,7 @@ describe("generateRedirectFileReactRouterV5", () => {
   import {Redirect,} from 'react-router'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, {}, props.urlQuery, props.origin);
+    const to = generateUrl(patternLogin, {}, props.query, props.origin);
     return (
       <>
         <Redirect to={to} />
@@ -53,7 +53,7 @@ describe("generateRedirectFileReactRouterV5", () => {
   import {Redirect,} from 'react-router'
   import {UrlPartsLogin,patternLogin,} from './patternLogin'
   const RedirectLogin: React.FunctionComponent<UrlPartsLogin & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(patternLogin, props.path, props.urlQuery, props.origin);
+    const to = generateUrl(patternLogin, props.path, props.query, props.origin);
     return (
       <>
         <Redirect to={to} />

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
@@ -23,7 +23,7 @@ const generateRedirectFileReactRouterV5 = (params: GenerateRedirectFileReactRout
     from: `./${patternNamedExports.filename}`,
   })}
   const ${functionName}: React.FunctionComponent<${patternNamedExports.urlPartsInterfaceName} & { fallback?: React.ReactNode }> = props => {
-    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.urlQuery, props.origin);
+    const to = generateUrl(${patternNamedExports.patternName}, ${hasPathParams ? "props.path" : "{}"}, props.query, props.origin);
     return (
       <>
         <Redirect to={to} />

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.test.ts
@@ -27,7 +27,7 @@ describe("generateUseRedirectReactRouterV5", () => {
   const useRedirectLogin = (): RedirectFnLogin => {
     const history = useHistory();
     const redirect: RedirectFnLogin = urlParts => {
-      const to = generateUrl(patternLogin, {}, urlParts?.urlQuery, urlParts?.origin);
+      const to = generateUrl(patternLogin, {}, urlParts?.query, urlParts?.origin);
       history.push(to);
     }
     return redirect;
@@ -62,7 +62,7 @@ describe("generateUseRedirectReactRouterV5", () => {
   const useRedirectUserInfo = (): RedirectFnUserInfo => {
     const history = useHistory();
     const redirect: RedirectFnUserInfo = urlParts => {
-      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.urlQuery, urlParts?.origin);
+      const to = generateUrl(patternUserInfo, urlParts.path, urlParts?.query, urlParts?.origin);
       history.push(to);
     }
     return redirect;

--- a/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
+++ b/src/generate/generateAppFiles/generatorReactRouterV5/generateUseRedirectReactRouterV5.ts
@@ -30,7 +30,7 @@ const generateUseRedirectReactRouterV5 = (params: GenerateUseRedirectReactRouter
   const ${functionName} = (): ${resultTypeInterface} => {
     const history = useHistory();
     const redirect: ${resultTypeInterface} = urlParts => {
-      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.urlQuery, urlParts?.origin);
+      const to = generateUrl(${patternNamedExports.patternName}, ${pathVariable}, urlParts?.query, urlParts?.origin);
       history.push(to);
     }
     return redirect;


### PR DESCRIPTION
## Template

- Change field `urlQuery`  to `query` in all interfaces for consistency