### PR TITLE
Use URLSearchParams to generate query string

### DIFF
--- a/src/generateUrl/generateUrl.test.ts
+++ b/src/generateUrl/generateUrl.test.ts
@@ -8,7 +8,7 @@ describe("generateUrl", () => {
     });
   });
 
-  describe("path - strings", () => {
+  describe("paths - strings", () => {
     it("should generate URL with required path param", () => {
       const result = generateUrl("/app/users/:id", { id: "onehundo" });
       expect(result).toBe("/app/users/onehundo");
@@ -97,8 +97,17 @@ describe("generateUrl", () => {
     });
 
     it("should generate multiple query strings correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage", redirect: "/login" });
-      expect(result).toBe("/app/users/oneHundo?from=homepage&redirect=/login");
+      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage", to: "login" });
+      expect(result).toBe("/app/users/oneHundo?from=homepage&to=login");
+    });
+
+    it("should encode special characters correctly", () => {
+      const result = generateUrl(
+        "/app/users/:id",
+        { id: "oneHundo" },
+        { from: "/homepage", redirect: "https://domain.com/login?from=/home" }
+      );
+      expect(result).toBe("/app/users/oneHundo?from=%2Fhomepage&redirect=https%3A%2F%2Fdomain.com%2Flogin%3Ffrom%3D%2Fhome");
     });
 
     it("should generate 1 undefined query string correctly", () => {
@@ -117,8 +126,8 @@ describe("generateUrl", () => {
     });
   });
 
-  describe("with prefix", () => {
-    it("should generate url with prefix", () => {
+  describe("with origin", () => {
+    it("should generate url with origin", () => {
       const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage" }, "https://test.domain");
       expect(result).toBe("https://test.domain/app/users/oneHundo?from=homepage");
     });

--- a/src/generateUrl/generateUrl.ts
+++ b/src/generateUrl/generateUrl.ts
@@ -23,24 +23,25 @@ const generatePath = (path = "/", params = {}): string => {
   return path === "/" ? path : compilePath(path)(params);
 };
 
-const generateQueryString = (urlQuery?: Record<string, string | undefined>): string => {
-  if (!urlQuery) {
+const generateQueryString = (query?: Record<string, string | undefined>): string => {
+  if (!query) {
     return "";
   }
 
-  const result = Object.entries(urlQuery)
-    .filter<[string, string]>((obj): obj is [string, string] => {
-      const value = obj[1];
-      return value !== undefined;
-    })
-    .reduce((prev, [key, value]) => prev.concat(key, "=", value, "&"), "?");
-  // remove the final '&'
-  return result.substring(0, result.length - 1);
+  const filteredQuery = Object.entries(query).filter<[string, string]>((obj): obj is [string, string] => {
+    const value = obj[1];
+    return value !== undefined;
+  });
+  if (filteredQuery.length === 0) {
+    return "";
+  }
+
+  return `?${new URLSearchParams(filteredQuery).toString()}`;
 };
 
-export type GenerateUrl = <P>(pattern: string, inputParams: P, urlQuery?: Record<string, string | undefined>, origin?: string) => string;
-const generateUrl: GenerateUrl = (pattern, inputParams, urlQuery, origin) => {
-  return (origin ?? "") + generatePath(pattern, inputParams as any) + generateQueryString(urlQuery);
+export type GenerateUrl = <P>(pattern: string, path: P, query?: Record<string, string | undefined>, origin?: string) => string;
+const generateUrl: GenerateUrl = (pattern, path, query, origin) => {
+  return (origin ?? "") + generatePath(pattern, path as any) + generateQueryString(query);
 };
 
 export default generateUrl;


### PR DESCRIPTION
### Utils

- Use `URLSearchParams` instead of manual function for creating query string in `generateUrl`