### PR TITLE
Better generated template for nextjs loose mode

### DIFF
--- a/.changeset/forty-teachers-refuse.md
+++ b/.changeset/forty-teachers-refuse.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": patch
+---
+
+NextJS loose mode templates use NextJS types for path params

--- a/packages/core/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorCore/generatePatternFile.test.ts
@@ -81,7 +81,7 @@ describe("generatePatternFile", () => {
           export const originUserInfo = ''
           export const patternNextJSUserInfo = '/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]'
           export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';singleEnum:'only';optional?: string;optionalEnum?:'enum1'|'enum2';}
-          export interface PathParamsNextJSUserInfo {id: string;subview: string;singleEnum: string;optional?: string;optionalEnum?: string;}
+          export interface PathParamsNextJSUserInfo {id: string | string[];subview: string | string[];singleEnum: string | string[];optional?: string | string[];optionalEnum?: string | string[];}
           export const possilePathParamsUserInfo = ['id','subview','singleEnum','optional','optionalEnum',]
           export interface UrlPartsUserInfo {
             path: PathParamsUserInfo;

--- a/packages/core/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorCore/generatePatternFile.ts
@@ -135,7 +135,7 @@ const generateNextJSPathParams = (keys: Key[], routeName: string): PathParamsInt
   keys.forEach((key) => {
     // TODO: check if NextJS support optional param?
     const fieldName = `${key.name}${keyHelpers.isOptional(key) ? "?" : ""}`;
-    template += `${fieldName}: string;`;
+    template += `${fieldName}: string | string[];`;
   });
   template += "}";
 

--- a/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.test.ts
@@ -19,7 +19,7 @@ describe("generateUseParamsFileNextJS", () => {
           import {useRouter,} from 'next/router'
           const useParamsUser = (): PathParamsNextJSUser => {
             const query = useRouter().query;
-            return {id: query.id,subview: query.subview,singleEnum: query.singleEnum,optional: query.optional ? (query.optional : undefined,optionalEnum: query.optionalEnum ? (query.optionalEnum : undefined,};
+            return {id: query.id,subview: query.subview,singleEnum: query.singleEnum,optional: query.optional ? query.optional : undefined,optionalEnum: query.optionalEnum ? query.optionalEnum : undefined,};
           }
           export default useParamsUser;"
     `);

--- a/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.test.ts
@@ -19,7 +19,7 @@ describe("generateUseParamsFileNextJS", () => {
           import {useRouter,} from 'next/router'
           const useParamsUser = (): PathParamsNextJSUser => {
             const query = useRouter().query;
-            return {id: query.id as PathParamsNextJSUser[\\"id\\"],subview: query.subview as PathParamsNextJSUser[\\"subview\\"],singleEnum: query.singleEnum as PathParamsNextJSUser[\\"singleEnum\\"],optional: query.optional ? (query.optional as PathParamsNextJSUser[\\"optional\\"]) : undefined,optionalEnum: query.optionalEnum ? (query.optionalEnum as PathParamsNextJSUser[\\"optionalEnum\\"]) : undefined,};
+            return {id: query.id,subview: query.subview,singleEnum: query.singleEnum,optional: query.optional ? (query.optional : undefined,optionalEnum: query.optionalEnum ? (query.optionalEnum : undefined,};
           }
           export default useParamsUser;"
     `);

--- a/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.ts
@@ -59,9 +59,9 @@ const generateUseParamsFileNextJS = (params: GenerateUseParamsFileNextJSParams):
     loose: function createLooseTemplate() {
       return `${keys.reduce((prev, key) => {
         if (isOptional(key)) {
-          return `${prev}${key.name}: query.${key.name} ? (query.${key.name} as ${printFieldType(key.name)}) : undefined,`;
+          return `${prev}${key.name}: query.${key.name} ? (query.${key.name} : undefined,`;
         }
-        return `${prev}${key.name}: query.${key.name} as ${printFieldType(key.name)},`;
+        return `${prev}${key.name}: query.${key.name},`;
       }, "")}`;
     },
   };

--- a/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorNextJS/generateUseParamsFileNextJS.ts
@@ -59,7 +59,7 @@ const generateUseParamsFileNextJS = (params: GenerateUseParamsFileNextJSParams):
     loose: function createLooseTemplate() {
       return `${keys.reduce((prev, key) => {
         if (isOptional(key)) {
-          return `${prev}${key.name}: query.${key.name} ? (query.${key.name} : undefined,`;
+          return `${prev}${key.name}: query.${key.name} ? query.${key.name} : undefined,`;
         }
         return `${prev}${key.name}: query.${key.name},`;
       }, "")}`;

--- a/sample/outputs/default/seo/routes/about/patternAbout.ts
+++ b/sample/outputs/default/seo/routes/about/patternAbout.ts
@@ -10,11 +10,11 @@ export type PathParamsAbout = {
   optionalEnum?: "enumOne" | "enumTwo";
 };
 export interface PathParamsNextJSAbout {
-  target: string;
-  topic: string;
-  region: string;
-  optional?: string;
-  optionalEnum?: string;
+  target: string | string[];
+  topic: string | string[];
+  region: string | string[];
+  optional?: string | string[];
+  optionalEnum?: string | string[];
 }
 export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlPartsAbout {

--- a/sample/outputs/default/seo/routes/about/useParamsAbout.ts
+++ b/sample/outputs/default/seo/routes/about/useParamsAbout.ts
@@ -4,11 +4,11 @@ import { useRouter } from "next/router";
 const useParamsAbout = (): PathParamsNextJSAbout => {
   const query = useRouter().query;
   return {
-    target: query.target as PathParamsNextJSAbout["target"],
-    topic: query.topic as PathParamsNextJSAbout["topic"],
-    region: query.region as PathParamsNextJSAbout["region"],
-    optional: query.optional ? (query.optional as PathParamsNextJSAbout["optional"]) : undefined,
-    optionalEnum: query.optionalEnum ? (query.optionalEnum as PathParamsNextJSAbout["optionalEnum"]) : undefined,
+    target: query.target,
+    topic: query.topic,
+    region: query.region,
+    optional: query.optional ? query.optional : undefined,
+    optionalEnum: query.optionalEnum ? query.optionalEnum : undefined,
   };
 };
 export default useParamsAbout;


### PR DESCRIPTION
For NextJS loose mode, return the normal type i.e. `string | string[]` for path param values instead of casting it to `string`. 
This makes it easier to adopt and use the type generation