### PR TITLE
Simplify params of utils/generateUrl

### DIFF
--- a/.changeset/calm-ads-help.md
+++ b/.changeset/calm-ads-help.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/utils": minor
+---
+
+Update generateUrl to take an object instead of normal params

--- a/packages/utils/src/generateUrl/generateUrl.test.ts
+++ b/packages/utils/src/generateUrl/generateUrl.test.ts
@@ -1,4 +1,4 @@
-import generateUrl from "./generateUrl";
+import { generateUrl } from "./generateUrl";
 
 describe("generateUrl", () => {
   describe("no path or query string", () => {

--- a/packages/utils/src/generateUrl/generateUrl.test.ts
+++ b/packages/utils/src/generateUrl/generateUrl.test.ts
@@ -3,88 +3,88 @@ import generateUrl from "./generateUrl";
 describe("generateUrl", () => {
   describe("no path or query string", () => {
     it("should generate URL with no dynamic path params or query string", () => {
-      const result = generateUrl("/app/login", {});
+      const result = generateUrl({ pattern: "/app/login", path: {} });
       expect(result).toBe("/app/login");
     });
   });
 
   describe("paths - strings", () => {
     it("should generate URL with required path param", () => {
-      const result = generateUrl("/app/users/:id", { id: "onehundo" });
+      const result = generateUrl({ pattern: "/app/users/:id", path: { id: "onehundo" } });
       expect(result).toBe("/app/users/onehundo");
     });
 
     it("should throw error if path param is required but not in path object", () => {
-      expect(() => generateUrl("/app/users/:id", {})).toThrowError('Expected "id" to be a string');
-      expect(() => generateUrl("/app/users/:id", { name: "Hundo" })).toThrowError('Expected "id" to be a string');
+      expect(() => generateUrl({ pattern: "/app/users/:id", path: {} })).toThrowError('Expected "id" to be a string');
+      expect(() => generateUrl({ pattern: "/app/users/:id", path: { name: "Hundo" } })).toThrowError('Expected "id" to be a string');
     });
 
     it("should generate URL if path param is not required and not in path object", () => {
-      const result = generateUrl("/app/users/:id?", {});
+      const result = generateUrl({ pattern: "/app/users/:id?", path: {} });
       expect(result).toBe("/app/users");
     });
 
     it("should generate URL if path param is not required but path is in path object", () => {
-      const result = generateUrl("/app/users/:id?", { id: "onehundo" });
+      const result = generateUrl({ pattern: "/app/users/:id?", path: { id: "onehundo" } });
       expect(result).toBe("/app/users/onehundo");
     });
 
     it("should generate URL with required path param", () => {
-      const result = generateUrl("/app/users/:id", { id: "onehundo" });
+      const result = generateUrl({ pattern: "/app/users/:id", path: { id: "onehundo" } });
       expect(result).toBe("/app/users/onehundo");
     });
 
     it("should throw error if path param is required but not in path object", () => {
-      expect(() => generateUrl("/app/users/:id", {})).toThrowError('Expected "id" to be a string');
-      expect(() => generateUrl("/app/users/:id", { name: "Hundo" })).toThrowError('Expected "id" to be a string');
+      expect(() => generateUrl({ pattern: "/app/users/:id", path: {} })).toThrowError('Expected "id" to be a string');
+      expect(() => generateUrl({ pattern: "/app/users/:id", path: { name: "Hundo" } })).toThrowError('Expected "id" to be a string');
     });
 
     it("should generate URL if path param is not required and not in path object", () => {
-      const result = generateUrl("/app/users/:id?", {});
+      const result = generateUrl({ pattern: "/app/users/:id?", path: {} });
       expect(result).toBe("/app/users");
     });
 
     it("should generate URL if path param is not required but path is in path object", () => {
-      const result = generateUrl("/app/users/:id?", { id: "onehundo" });
+      const result = generateUrl({ pattern: "/app/users/:id?", path: { id: "onehundo" } });
       expect(result).toBe("/app/users/onehundo");
     });
   });
 
   describe("paths - enums", () => {
     it("should generate URL with required enum path param", () => {
-      const result = generateUrl("/app/users/:subview(profile|pictures)", { subview: "profile" });
+      const result = generateUrl({ pattern: "/app/users/:subview(profile|pictures)", path: { subview: "profile" } });
       expect(result).toBe("/app/users/profile");
     });
 
     it("should throw error with required enum path param and path is not in path object", () => {
-      expect(() => generateUrl("/app/users/:subview(profile|pictures)", { house: "profile" })).toThrowError(
+      expect(() => generateUrl({ pattern: "/app/users/:subview(profile|pictures)", path: { house: "profile" } })).toThrowError(
         'Expected "subview" to be a string'
       );
     });
 
     it("should throw error with required enum path param and path is not part of enums", () => {
-      expect(() => generateUrl("/app/users/:subview(profile|pictures)", { subview: "dog" })).toThrowError(
+      expect(() => generateUrl({ pattern: "/app/users/:subview(profile|pictures)", path: { subview: "dog" } })).toThrowError(
         'Expected "subview" to match "profile|pictures", but got "dog"'
       );
     });
 
     it("should generate URL with optional enum path param and path not in path object", () => {
-      const result = generateUrl("/app/users/:subview(profile|pictures)?", {});
+      const result = generateUrl({ pattern: "/app/users/:subview(profile|pictures)?", path: {} });
       expect(result).toBe("/app/users");
     });
 
     it("should generate URL with optional enum path param and path in path object", () => {
-      const result = generateUrl("/app/users/:subview(profile|pictures)?", { subview: "profile" });
+      const result = generateUrl({ pattern: "/app/users/:subview(profile|pictures)?", path: { subview: "profile" } });
       expect(result).toBe("/app/users/profile");
     });
 
     it("should generate URL with optional enum path param and path is not in path object", () => {
-      const result = generateUrl("/app/users/:subview(profile|pictures)?", { house: "profile" });
+      const result = generateUrl({ pattern: "/app/users/:subview(profile|pictures)?", path: { house: "profile" } });
       expect(result).toBe("/app/users");
     });
 
     it("should throw error with optional enum path param and path is not part of enums", () => {
-      expect(() => generateUrl("/app/users/:subview(profile|pictures)?", { subview: "dog" })).toThrowError(
+      expect(() => generateUrl({ pattern: "/app/users/:subview(profile|pictures)?", path: { subview: "dog" } })).toThrowError(
         'Expected "subview" to match "profile|pictures", but got "dog"'
       );
     });
@@ -92,43 +92,60 @@ describe("generateUrl", () => {
 
   describe("query strings", () => {
     it("should generate one query string correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage" });
+      const result = generateUrl({ pattern: "/app/users/:id", path: { id: "oneHundo" }, query: { from: "homepage" } });
       expect(result).toBe("/app/users/oneHundo?from=homepage");
     });
 
     it("should generate multiple query strings correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage", to: "login" });
+      const result = generateUrl({ pattern: "/app/users/:id", path: { id: "oneHundo" }, query: { from: "homepage", to: "login" } });
       expect(result).toBe("/app/users/oneHundo?from=homepage&to=login");
     });
 
     it("should encode special characters correctly", () => {
-      const result = generateUrl(
-        "/app/users/:id",
-        { id: "oneHundo" },
-        { from: "/homepage", redirect: "https://domain.com/login?from=/home" }
-      );
+      const result = generateUrl({
+        pattern: "/app/users/:id",
+        path: { id: "oneHundo" },
+        query: { from: "/homepage", redirect: "https://domain.com/login?from=/home" },
+      });
       expect(result).toBe("/app/users/oneHundo?from=%2Fhomepage&redirect=https%3A%2F%2Fdomain.com%2Flogin%3Ffrom%3D%2Fhome");
     });
 
     it("should generate 1 undefined query string correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: undefined });
+      const result = generateUrl({
+        pattern: "/app/users/:id",
+        path: { id: "oneHundo" },
+        query: { from: undefined },
+      });
       expect(result).toBe("/app/users/oneHundo");
     });
 
     it("should generate more than 1 undefined query string correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: undefined, redirect: undefined });
+      const result = generateUrl({
+        pattern: "/app/users/:id",
+        path: { id: "oneHundo" },
+        query: { from: undefined, redirect: undefined },
+      });
       expect(result).toBe("/app/users/oneHundo");
     });
 
     it("should generate mixed undefined and string correctly", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage", redirect: undefined, to: "test" });
+      const result = generateUrl({
+        pattern: "/app/users/:id",
+        path: { id: "oneHundo" },
+        query: { from: "homepage", redirect: undefined, to: "test" },
+      });
       expect(result).toBe("/app/users/oneHundo?from=homepage&to=test");
     });
   });
 
   describe("with origin", () => {
     it("should generate url with origin", () => {
-      const result = generateUrl("/app/users/:id", { id: "oneHundo" }, { from: "homepage" }, "https://test.domain");
+      const result = generateUrl({
+        pattern: "/app/users/:id",
+        path: { id: "oneHundo" },
+        query: { from: "homepage" },
+        origin: "https://test.domain",
+      });
       expect(result).toBe("https://test.domain/app/users/oneHundo?from=homepage");
     });
   });

--- a/packages/utils/src/generateUrl/generateUrl.ts
+++ b/packages/utils/src/generateUrl/generateUrl.ts
@@ -40,8 +40,16 @@ const generateQueryString = (query?: Record<string, string | undefined>): string
   return `?${new URLSearchParams(filteredQuery).toString()}`;
 };
 
-export type GenerateUrl = <P>(pattern: string, path: P, query?: Record<string, string | undefined>, origin?: string) => string;
-const generateUrl: GenerateUrl = (pattern, path, query, origin) => {
+export interface UrlParams<P> {
+  pattern: string;
+  path: P;
+  query?: Record<string, string | undefined>;
+  origin?: string;
+}
+
+export type GenerateUrl = <P>(params: UrlParams<P>) => string;
+
+const generateUrl: GenerateUrl = ({ pattern, path, query, origin }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (origin ?? "") + generatePath(pattern, path as any) + generateQueryString(query);
 };

--- a/packages/utils/src/generateUrl/generateUrl.ts
+++ b/packages/utils/src/generateUrl/generateUrl.ts
@@ -49,9 +49,7 @@ export interface UrlParams<P> {
 
 export type GenerateUrl = <P>(params: UrlParams<P>) => string;
 
-const generateUrl: GenerateUrl = ({ pattern, path, query, origin }) => {
+export const generateUrl: GenerateUrl = ({ pattern, path, query, origin }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (origin ?? "") + generatePath(pattern, path as any) + generateQueryString(query);
 };
-
-export default generateUrl;

--- a/packages/utils/src/generateUrl/index.ts
+++ b/packages/utils/src/generateUrl/index.ts
@@ -1,2 +1,1 @@
-export { default } from "./generateUrl";
 export * from "./generateUrl";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,1 @@
-export { default as generateUrl } from "./generateUrl";
 export * from "./generateUrl";


### PR DESCRIPTION
This will make generateUrl params an object to make it easier to pass around