### PR TITLE
Standardise url params usage in Link components

### DIFF
--- a/.changeset/tiny-cameras-switch.md
+++ b/.changeset/tiny-cameras-switch.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": minor
+---
+
+[Breaking change] Update Link component props to handle urlParams as the main routing props

--- a/packages/core/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.test.ts
@@ -52,9 +52,9 @@ describe("generateLinkFileDefault", () => {
           import {generateUrl,} from 'route-codegen'
           import Link, {CustomLinkProps,} from 'src/Default/Link'
           import {patternLogin,UrlParamsLogin,originLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+          type LinkLoginProps = Omit<CustomLinkProps, 'customDefaultHref'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
             return <Link {...props} customDefaultHref={to} />;
           }"
       `);
@@ -71,9 +71,9 @@ describe("generateLinkFileDefault", () => {
           import {generateUrl,} from 'route-codegen'
           
           import {patternLogin,UrlParamsLogin,originLogin,} from './patternLogin'
-          type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({  query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+          type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
             return <a {...props} href={to} />;
           }"
       `);
@@ -96,9 +96,9 @@ describe("generateLinkFileDefault", () => {
           import {generateUrl,} from 'route-codegen'
           
           import {patternLogin,UrlParamsLogin,originLogin,} from './patternLogin'
-          type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ path, query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: path, query, origin: origin ?? originLogin });
+          type InlineLinkProps = Omit<React.SomeReallyLongReactHTMLProps, 'href'> & { urlParams: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<InlineLinkProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
             return <a {...props} href={to} />;
           }"
       `);
@@ -129,9 +129,9 @@ describe("generateLinkFileDefault", () => {
           import {generateUrl,} from 'route-codegen'
           import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
           import {patternLogin,UrlParamsLogin,originLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
             return <Link {...props} to={to} />;
           }"
       `);

--- a/packages/core/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorDefault/generateLinkFileDefault.ts
@@ -30,6 +30,7 @@ export const generateLinkFileDefault = (params: GenerateLinkFileDefaultParams): 
     defaultLinkPropsInterfaceName,
     urlParamsInterfaceName,
     routeLinkOption,
+    hasPathParams,
   });
 
   const template = `${printImport({ defaultImport: "React", from: "react" })}
@@ -40,10 +41,10 @@ export const generateLinkFileDefault = (params: GenerateLinkFileDefaultParams): 
     from: `./${routePatternFilename}`,
   })}
   ${linkPropsTemplate}
-  export const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
-    hasPathParams ? "path," : ""
-  } query, origin, ...props }) => {
-    const to = generateUrl(${patternName}, { path: ${hasPathParams ? "path" : "{}"}, query, origin: origin ?? ${originName} });
+  export const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ urlParams, ...props }) => {
+    const to = generateUrl(${patternName}, { path: ${
+    hasPathParams ? "urlParams.path" : "{}"
+  }, query: urlParams?.query, origin: urlParams?.origin ?? ${originName} });
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }`;
 
@@ -64,6 +65,7 @@ interface GenerateLinkInterfaceParams {
   routeLinkOption: RouteLinkOptions["Default"];
   defaultLinkPropsInterfaceName: string;
   urlParamsInterfaceName: string;
+  hasPathParams: boolean;
 }
 
 interface GenerateLinkInterfaceResult {
@@ -76,15 +78,17 @@ interface GenerateLinkInterfaceResult {
 }
 
 const generateLinkInterface = (params: GenerateLinkInterfaceParams): GenerateLinkInterfaceResult => {
-  const { routeLinkOption, defaultLinkPropsInterfaceName, urlParamsInterfaceName } = params;
-
+  const { routeLinkOption, defaultLinkPropsInterfaceName, urlParamsInterfaceName, hasPathParams } = params;
   const { hrefProp, linkProps, importLink, linkComponent } = routeLinkOption;
 
+  const urlParamsModifier = hasPathParams ? "" : "?";
+  const urlParamsTemplate = `{ urlParams${urlParamsModifier}: ${urlParamsInterfaceName} }`;
+
   // if there's inlineLinkPropsTemplate, we don't import anything
-  let linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'> & ${urlParamsInterfaceName}`;
+  let linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'> & ${urlParamsTemplate}`;
   let linkPropsInterfaceName = defaultLinkPropsInterfaceName;
   if ("inlineLinkProps" in routeLinkOption && routeLinkOption.inlineLinkProps) {
-    linkPropsTemplate = `${routeLinkOption.inlineLinkProps.template} & ${urlParamsInterfaceName}`;
+    linkPropsTemplate = `${routeLinkOption.inlineLinkProps.template} & ${urlParamsTemplate}`;
     linkPropsInterfaceName = routeLinkOption.inlineLinkProps.linkProps;
   }
 

--- a/packages/core/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorNextJS/generateLinkFileNextJS.test.ts
@@ -39,9 +39,10 @@ describe("generateLinkFileNextJS", () => {
         "import React from 'react'
           import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
           import {UrlParamsLogin,patternNextJSLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-            const { query = {}, ...rest } = props; const path = {};
+          type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
+            const { query = {} } = urlParams;
+            const path = {};
             const pathname = patternNextJSLogin;
             const nextHref = {
               pathname: pathname,
@@ -50,7 +51,7 @@ describe("generateLinkFileNextJS", () => {
                 ...query,
               },
             }
-            return <Link {...rest} customHref={nextHref} />;
+            return <Link {...props} customHref={nextHref} />;
           }"
       `);
     });
@@ -72,9 +73,10 @@ describe("generateLinkFileNextJS", () => {
         "import React from 'react'
           import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
           import {UrlParamsLogin,patternNextJSLogin,possiblePathParamsLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-            const { path = {}, query = {}, ...rest } = props;
+          type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & { urlParams: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
+            const { query = {} } = urlParams;
+            const path = urlParams.path;
             const pathname = possiblePathParamsLogin.filter((key) => !(key in path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[\${suppliedParam}]\`, \\"\\"), patternNextJSLogin);
             const nextHref = {
               pathname: pathname,
@@ -83,7 +85,7 @@ describe("generateLinkFileNextJS", () => {
                 ...query,
               },
             }
-            return <Link {...rest} customHref={nextHref} />;
+            return <Link {...props} customHref={nextHref} />;
           }"
       `);
     });
@@ -113,9 +115,10 @@ describe("generateLinkFileNextJS", () => {
         "import React from 'react'
           import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
           import {UrlParamsLogin,patternNextJSLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = props => {
-            const { query = {}, ...rest } = props; const path = {};
+          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
+            const { query = {} } = urlParams;
+            const path = {};
             const pathname = patternNextJSLogin;
             const nextHref = {
               pathname: pathname,
@@ -124,7 +127,7 @@ describe("generateLinkFileNextJS", () => {
                 ...query,
               },
             }
-            return <Link {...rest} to={nextHref} />;
+            return <Link {...props} to={nextHref} />;
           }"
       `);
     });

--- a/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.test.ts
@@ -41,9 +41,9 @@ describe("generateLinkFileReactRouterV5", () => {
           import {generateUrl,} from 'route-codegen'
           import Link, {CustomLinkProps,} from 'src/common/Link'
           import {patternLogin,UrlParamsLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: {}, query, origin });
+          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
             return <Link {...props} to={to} />;
           }"
       `);
@@ -66,9 +66,9 @@ describe("generateLinkFileReactRouterV5", () => {
           import {generateUrl,} from 'route-codegen'
           import Link, {CustomLinkProps,} from 'src/common/Link'
           import {patternLogin,UrlParamsLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ path, query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: path, query, origin });
+          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
             return <Link {...props} to={to} />;
           }"
       `);
@@ -101,9 +101,9 @@ describe("generateLinkFileReactRouterV5", () => {
           import {generateUrl,} from 'route-codegen'
           import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
           import {patternLogin,UrlParamsLogin,} from './patternLogin'
-          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & UrlParamsLogin
-          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({  query, origin, ...props }) => {
-            const to = generateUrl(patternLogin, { path: {}, query, origin });
+          type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams?: UrlParamsLogin }
+          export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+            const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
             return <Link {...props} to={to} />;
           }"
       `);

--- a/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateLinkFileReactRouterV5.ts
@@ -31,6 +31,7 @@ export const generateLinkFileReactRouterV5 = (params: GenerateLinkFileReactRoute
     defaultLinkPropsInterfaceName,
     urlParamsInterfaceName,
     routeLinkOption,
+    hasPathParams,
   });
 
   const template = `${printImport({ defaultImport: "React", from: "react" })}
@@ -41,10 +42,10 @@ export const generateLinkFileReactRouterV5 = (params: GenerateLinkFileReactRoute
     from: `./${routePatternFilename}`,
   })}
   ${linkPropsTemplate}
-  export const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ ${
-    hasPathParams ? "path," : ""
-  } query, origin, ...props }) => {
-    const to = ${generateUrlFnName}(${patternName}, { path: ${hasPathParams ? "path" : "{}"}, query, origin });
+  export const ${functionName}: React.FunctionComponent<${linkPropsInterfaceName}> = ({ urlParams, ...props }) => {
+    const to = ${generateUrlFnName}(${patternName}, { path: ${
+    hasPathParams ? "urlParams.path" : "{}"
+  }, query: urlParams?.query, origin: urlParams?.origin });
     return <${linkComponent} {...props} ${hrefProp}={to} />;
   }`;
 
@@ -65,6 +66,7 @@ interface GenerateLinkInterfaceParams {
   routeLinkOption: RouteLinkOptions["ReactRouterV5"];
   defaultLinkPropsInterfaceName: string;
   urlParamsInterfaceName: string;
+  hasPathParams: boolean;
 }
 
 interface GenerateLinkInterfaceResult {
@@ -77,11 +79,13 @@ interface GenerateLinkInterfaceResult {
 }
 
 const generateLinkInterface = (params: GenerateLinkInterfaceParams): GenerateLinkInterfaceResult => {
-  const { routeLinkOption, defaultLinkPropsInterfaceName, urlParamsInterfaceName } = params;
-
+  const { routeLinkOption, defaultLinkPropsInterfaceName, urlParamsInterfaceName, hasPathParams } = params;
   const { hrefProp, linkProps, importLink, linkComponent } = routeLinkOption;
 
-  const linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'> & ${urlParamsInterfaceName}`;
+  const urlParamsModifier = hasPathParams ? "" : "?";
+  const urlParamsTemplate = `{ urlParams${urlParamsModifier}: ${urlParamsInterfaceName} }`;
+
+  const linkPropsTemplate = `type ${defaultLinkPropsInterfaceName} = Omit<${linkProps}, '${hrefProp}'> & ${urlParamsTemplate}`;
   const linkPropsInterfaceName = defaultLinkPropsInterfaceName;
 
   return {

--- a/sample/outputs/default/app/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/app/routes/about/LinkAbout.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternAbout, UrlParamsAbout, originAbout } from "./patternAbout";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsAbout;
-export const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternAbout, { path: path, query, origin: origin ?? originAbout });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsAbout;
+};
+export const LinkAbout: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originAbout });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/account/LinkAccount.tsx
+++ b/sample/outputs/default/app/routes/account/LinkAccount.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { LinkProps, Link } from "react-router-dom";
 import { patternAccount, UrlParamsAccount } from "./patternAccount";
-type LinkAccountProps = Omit<LinkProps, "to"> & UrlParamsAccount;
-export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternAccount, { path: {}, query, origin });
+type LinkAccountProps = Omit<LinkProps, "to"> & { urlParams?: UrlParamsAccount };
+export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
   return <Link {...props} to={to} />;
 };

--- a/sample/outputs/default/app/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/app/routes/contact/LinkContact.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternContact, UrlParamsContact, originContact } from "./patternContact";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsContact;
-export const LinkContact: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternContact, { path: path, query, origin: origin ?? originContact });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsContact;
+};
+export const LinkContact: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originContact });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/app/routes/home/LinkHome.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternHome, UrlParamsHome, originHome } from "./patternHome";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternHome, { path: {}, query, origin: origin ?? originHome });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsHome;
+};
+export const LinkHome: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originHome });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/default/app/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLegacy;
+};
+export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/login/LinkLogin.tsx
+++ b/sample/outputs/default/app/routes/login/LinkLogin.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLogin, UrlParamsLogin, originLogin } from "./patternLogin";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLogin;
-export const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLogin;
+};
+export const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/signup/LinkSignup.tsx
+++ b/sample/outputs/default/app/routes/signup/LinkSignup.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternSignup, UrlParamsSignup, originSignup } from "./patternSignup";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsSignup;
-export const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternSignup, { path: {}, query, origin: origin ?? originSignup });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsSignup;
+};
+export const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originSignup });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/app/routes/toc/LinkToc.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternToc, UrlParamsToc, originToc } from "./patternToc";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsToc;
-export const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternToc, { path: {}, query, origin: origin ?? originToc });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsToc;
+};
+export const LinkToc: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originToc });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/app/routes/user/LinkUser.tsx
+++ b/sample/outputs/default/app/routes/user/LinkUser.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlParamsUser } from "./patternUser";
-type LinkUserProps = Omit<LinkProps, "to"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin });
+type LinkUserProps = Omit<LinkProps, "to"> & { urlParams: UrlParamsUser };
+export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
   return <Link {...props} to={to} />;
 };

--- a/sample/outputs/default/auth/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/auth/routes/about/LinkAbout.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAbout, UrlParamsAbout, originAbout } from "./patternAbout";
-type LinkAboutProps = Omit<AnchorProps, "href"> & UrlParamsAbout;
-export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternAbout, { path: path, query, origin: origin ?? originAbout });
+type LinkAboutProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsAbout };
+export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originAbout });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/account/LinkAccount.tsx
+++ b/sample/outputs/default/auth/routes/account/LinkAccount.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternAccount, UrlParamsAccount, originAccount } from "./patternAccount";
-type LinkAccountProps = Omit<AnchorProps, "href"> & UrlParamsAccount;
-export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternAccount, { path: {}, query, origin: origin ?? originAccount });
+type LinkAccountProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsAccount };
+export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originAccount });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/auth/routes/contact/LinkContact.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternContact, UrlParamsContact, originContact } from "./patternContact";
-type LinkContactProps = Omit<AnchorProps, "href"> & UrlParamsContact;
-export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternContact, { path: path, query, origin: origin ?? originContact });
+type LinkContactProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsContact };
+export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originContact });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/auth/routes/home/LinkHome.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternHome, UrlParamsHome, originHome } from "./patternHome";
-type LinkHomeProps = Omit<AnchorProps, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternHome, { path: {}, query, origin: origin ?? originHome });
+type LinkHomeProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsHome };
+export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originHome });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/default/auth/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkLegacyProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsLegacy };
+export const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/login/LinkLogin.tsx
+++ b/sample/outputs/default/auth/routes/login/LinkLogin.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { LinkProps } from "common/components/Link";
 import { patternLogin, UrlParamsLogin } from "./patternLogin";
-type LinkLoginProps = Omit<LinkProps, "to"> & UrlParamsLogin;
-export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLogin, { path: {}, query, origin });
+type LinkLoginProps = Omit<LinkProps, "to"> & { urlParams?: UrlParamsLogin };
+export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
   return <Link {...props} to={to} />;
 };

--- a/sample/outputs/default/auth/routes/signup/LinkSignup.tsx
+++ b/sample/outputs/default/auth/routes/signup/LinkSignup.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { LinkProps } from "common/components/Link";
 import { patternSignup, UrlParamsSignup } from "./patternSignup";
-type LinkSignupProps = Omit<LinkProps, "to"> & UrlParamsSignup;
-export const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternSignup, { path: {}, query, origin });
+type LinkSignupProps = Omit<LinkProps, "to"> & { urlParams?: UrlParamsSignup };
+export const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
   return <Link {...props} to={to} />;
 };

--- a/sample/outputs/default/auth/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/auth/routes/toc/LinkToc.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternToc, UrlParamsToc, originToc } from "./patternToc";
-type LinkTocProps = Omit<AnchorProps, "href"> & UrlParamsToc;
-export const LinkToc: React.FunctionComponent<LinkTocProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternToc, { path: {}, query, origin: origin ?? originToc });
+type LinkTocProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsToc };
+export const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originToc });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/auth/routes/user/LinkUser.tsx
+++ b/sample/outputs/default/auth/routes/user/LinkUser.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { AnchorProps, CustomAnchor as Link } from "common/ui/Anchor";
 import { patternUser, UrlParamsUser, originUser } from "./patternUser";
-type LinkUserProps = Omit<AnchorProps, "href"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin: origin ?? originUser });
+type LinkUserProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsUser };
+export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originUser });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/seo-strict/routes/about/LinkAbout.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternAbout, UrlParamsAbout, originAbout } from "./patternAbout";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsAbout;
-export const LinkAbout: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternAbout, { path: path, query, origin: origin ?? originAbout });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsAbout;
+};
+export const LinkAbout: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originAbout });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/account/LinkAccount.tsx
+++ b/sample/outputs/default/seo-strict/routes/account/LinkAccount.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternAccount, UrlParamsAccount, originAccount } from "./patternAccount";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsAccount;
-export const LinkAccount: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternAccount, { path: {}, query, origin: origin ?? originAccount });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsAccount;
+};
+export const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originAccount });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/seo-strict/routes/contact/LinkContact.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlParamsContact, patternNextJSContact, possilePathParamsContact } from "./patternContact";
-type LinkContactProps = Omit<LinkProps, "href"> & UrlParamsContact;
-export const LinkContact: React.FunctionComponent<LinkContactProps> = (props) => {
-  const { path = {}, query = {}, ...rest } = props;
+type LinkContactProps = Omit<LinkProps, "href"> & { urlParams: UrlParamsContact };
+export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
+  const path = urlParams.path;
   const pathname = possilePathParamsContact
     .filter((key) => !(key in path))
     .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSContact);
@@ -15,5 +16,5 @@ export const LinkContact: React.FunctionComponent<LinkContactProps> = (props) =>
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/default/seo-strict/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/seo-strict/routes/home/LinkHome.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternHome, UrlParamsHome, originHome } from "./patternHome";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternHome, { path: {}, query, origin: origin ?? originHome });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsHome;
+};
+export const LinkHome: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originHome });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/default/seo-strict/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLegacy;
+};
+export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/login/LinkLogin.tsx
+++ b/sample/outputs/default/seo-strict/routes/login/LinkLogin.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLogin, UrlParamsLogin, originLogin } from "./patternLogin";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLogin;
-export const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLogin;
+};
+export const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/signup/LinkSignup.tsx
+++ b/sample/outputs/default/seo-strict/routes/signup/LinkSignup.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternSignup, UrlParamsSignup, originSignup } from "./patternSignup";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsSignup;
-export const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternSignup, { path: {}, query, origin: origin ?? originSignup });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsSignup;
+};
+export const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originSignup });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/seo-strict/routes/toc/LinkToc.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternToc, UrlParamsToc, originToc } from "./patternToc";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsToc;
-export const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternToc, { path: {}, query, origin: origin ?? originToc });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsToc;
+};
+export const LinkToc: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originToc });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo-strict/routes/user/LinkUser.tsx
+++ b/sample/outputs/default/seo-strict/routes/user/LinkUser.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternUser, UrlParamsUser, originUser } from "./patternUser";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin: origin ?? originUser });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsUser;
+};
+export const LinkUser: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originUser });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/seo/routes/about/LinkAbout.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlParamsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
-type LinkAboutProps = Omit<LinkProps, "href"> & UrlParamsAbout;
-export const LinkAbout: React.FunctionComponent<LinkAboutProps> = (props) => {
-  const { path = {}, query = {}, ...rest } = props;
+type LinkAboutProps = Omit<LinkProps, "href"> & { urlParams: UrlParamsAbout };
+export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
+  const path = urlParams.path;
   const pathname = possilePathParamsAbout
     .filter((key) => !(key in path))
     .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);
@@ -15,5 +16,5 @@ export const LinkAbout: React.FunctionComponent<LinkAboutProps> = (props) => {
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/default/seo/routes/account/LinkAccount.tsx
+++ b/sample/outputs/default/seo/routes/account/LinkAccount.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternAccount, UrlParamsAccount, originAccount } from "./patternAccount";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsAccount;
-export const LinkAccount: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternAccount, { path: {}, query, origin: origin ?? originAccount });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsAccount;
+};
+export const LinkAccount: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originAccount });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/seo/routes/contact/LinkContact.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternContact, UrlParamsContact, originContact } from "./patternContact";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsContact;
-export const LinkContact: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternContact, { path: path, query, origin: origin ?? originContact });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsContact;
+};
+export const LinkContact: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originContact });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/seo/routes/home/LinkHome.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlParamsHome, patternNextJSHome } from "./patternHome";
-type LinkHomeProps = Omit<LinkProps, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
-  const { query = {}, ...rest } = props;
+type LinkHomeProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsHome };
+export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
   const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
@@ -14,5 +14,5 @@ export const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/default/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/default/seo/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLegacy;
+};
+export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/login/LinkLogin.tsx
+++ b/sample/outputs/default/seo/routes/login/LinkLogin.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLogin, UrlParamsLogin, originLogin } from "./patternLogin";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLogin;
-export const LinkLogin: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLogin;
+};
+export const LinkLogin: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/signup/LinkSignup.tsx
+++ b/sample/outputs/default/seo/routes/signup/LinkSignup.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternSignup, UrlParamsSignup, originSignup } from "./patternSignup";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsSignup;
-export const LinkSignup: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternSignup, { path: {}, query, origin: origin ?? originSignup });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsSignup;
+};
+export const LinkSignup: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originSignup });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/seo/routes/toc/LinkToc.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternToc, UrlParamsToc, originToc } from "./patternToc";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsToc;
-export const LinkToc: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternToc, { path: {}, query, origin: origin ?? originToc });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsToc;
+};
+export const LinkToc: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originToc });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/seo/routes/user/LinkUser.tsx
+++ b/sample/outputs/default/seo/routes/user/LinkUser.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternUser, UrlParamsUser, originUser } from "./patternUser";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin: origin ?? originUser });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsUser;
+};
+export const LinkUser: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originUser });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/toc/routes/about/LinkAbout.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAbout, UrlParamsAbout, originAbout } from "./patternAbout";
-type LinkAboutProps = Omit<AnchorProps, "href"> & UrlParamsAbout;
-export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternAbout, { path: path, query, origin: origin ?? originAbout });
+type LinkAboutProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsAbout };
+export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originAbout });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/account/LinkAccount.tsx
+++ b/sample/outputs/default/toc/routes/account/LinkAccount.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternAccount, UrlParamsAccount, originAccount } from "./patternAccount";
-type LinkAccountProps = Omit<AnchorProps, "href"> & UrlParamsAccount;
-export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternAccount, { path: {}, query, origin: origin ?? originAccount });
+type LinkAccountProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsAccount };
+export const LinkAccount: React.FunctionComponent<LinkAccountProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originAccount });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/toc/routes/contact/LinkContact.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternContact, UrlParamsContact, originContact } from "./patternContact";
-type LinkContactProps = Omit<AnchorProps, "href"> & UrlParamsContact;
-export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternContact, { path: path, query, origin: origin ?? originContact });
+type LinkContactProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsContact };
+export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originContact });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/toc/routes/home/LinkHome.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternHome, UrlParamsHome, originHome } from "./patternHome";
-type LinkHomeProps = Omit<AnchorProps, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternHome, { path: {}, query, origin: origin ?? originHome });
+type LinkHomeProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsHome };
+export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originHome });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/default/toc/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkLegacyProps = Omit<AnchorProps, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkLegacyProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsLegacy };
+export const LinkLegacy: React.FunctionComponent<LinkLegacyProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/login/LinkLogin.tsx
+++ b/sample/outputs/default/toc/routes/login/LinkLogin.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternLogin, UrlParamsLogin, originLogin } from "./patternLogin";
-type LinkLoginProps = Omit<AnchorProps, "href"> & UrlParamsLogin;
-export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLogin, { path: {}, query, origin: origin ?? originLogin });
+type LinkLoginProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsLogin };
+export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLogin });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/signup/LinkSignup.tsx
+++ b/sample/outputs/default/toc/routes/signup/LinkSignup.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternSignup, UrlParamsSignup, originSignup } from "./patternSignup";
-type LinkSignupProps = Omit<AnchorProps, "href"> & UrlParamsSignup;
-export const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternSignup, { path: {}, query, origin: origin ?? originSignup });
+type LinkSignupProps = Omit<AnchorProps, "href"> & { urlParams?: UrlParamsSignup };
+export const LinkSignup: React.FunctionComponent<LinkSignupProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originSignup });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/default/toc/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/toc/routes/toc/LinkToc.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import Link, { LinkProps } from "src/common/components/Link";
 import { UrlParamsToc, patternNextJSToc } from "./patternToc";
-type LinkTocProps = Omit<LinkProps, "href"> & UrlParamsToc;
-export const LinkToc: React.FunctionComponent<LinkTocProps> = (props) => {
-  const { query = {}, ...rest } = props;
+type LinkTocProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsToc };
+export const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
   const path = {};
   const pathname = patternNextJSToc;
   const nextHref = {
@@ -14,5 +14,5 @@ export const LinkToc: React.FunctionComponent<LinkTocProps> = (props) => {
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/default/toc/routes/user/LinkUser.tsx
+++ b/sample/outputs/default/toc/routes/user/LinkUser.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import Link, { AnchorProps } from "src/common/ui/Anchor";
 import { patternUser, UrlParamsUser, originUser } from "./patternUser";
-type LinkUserProps = Omit<AnchorProps, "href"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin: origin ?? originUser });
+type LinkUserProps = Omit<AnchorProps, "href"> & { urlParams: UrlParamsUser };
+export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originUser });
   return <Link {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/activateAccount/LinkActivateAccount.tsx
+++ b/sample/outputs/with-origins/app/routes/activateAccount/LinkActivateAccount.tsx
@@ -3,9 +3,14 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternActivateAccount, UrlParamsActivateAccount, originActivateAccount } from "./patternActivateAccount";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> &
-  UrlParamsActivateAccount;
-export const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternActivateAccount, { path: path, query, origin: origin ?? originActivateAccount });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsActivateAccount;
+};
+export const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternActivateAccount, {
+    path: urlParams.path,
+    query: urlParams?.query,
+    origin: urlParams?.origin ?? originActivateAccount,
+  });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/graphql/LinkGraphql.tsx
+++ b/sample/outputs/with-origins/app/routes/graphql/LinkGraphql.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternGraphql, UrlParamsGraphql, originGraphql } from "./patternGraphql";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsGraphql;
-export const LinkGraphql: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternGraphql, { path: {}, query, origin: origin ?? originGraphql });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsGraphql;
+};
+export const LinkGraphql: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternGraphql, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originGraphql });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/home/LinkHome.tsx
+++ b/sample/outputs/with-origins/app/routes/home/LinkHome.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternHome, UrlParamsHome, originHome } from "./patternHome";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternHome, { path: {}, query, origin: origin ?? originHome });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsHome;
+};
+export const LinkHome: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originHome });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/with-origins/app/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLegacy;
+};
+export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/terms/LinkTerms.tsx
+++ b/sample/outputs/with-origins/app/routes/terms/LinkTerms.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternTerms, UrlParamsTerms, originTerms } from "./patternTerms";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsTerms;
-export const LinkTerms: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternTerms, { path: {}, query, origin: origin ?? originTerms });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsTerms;
+};
+export const LinkTerms: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternTerms, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originTerms });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/app/routes/user/LinkUser.tsx
+++ b/sample/outputs/with-origins/app/routes/user/LinkUser.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { LinkProps, Link } from "react-router-dom";
 import { patternUser, UrlParamsUser } from "./patternUser";
-type LinkUserProps = Omit<LinkProps, "to"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin });
+type LinkUserProps = Omit<LinkProps, "to"> & { urlParams: UrlParamsUser };
+export const LinkUser: React.FunctionComponent<LinkUserProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
   return <Link {...props} to={to} />;
 };

--- a/sample/outputs/with-origins/seo/routes/activateAccount/LinkActivateAccount.tsx
+++ b/sample/outputs/with-origins/seo/routes/activateAccount/LinkActivateAccount.tsx
@@ -3,9 +3,14 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternActivateAccount, UrlParamsActivateAccount, originActivateAccount } from "./patternActivateAccount";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> &
-  UrlParamsActivateAccount;
-export const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternActivateAccount, { path: path, query, origin: origin ?? originActivateAccount });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsActivateAccount;
+};
+export const LinkActivateAccount: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternActivateAccount, {
+    path: urlParams.path,
+    query: urlParams?.query,
+    origin: urlParams?.origin ?? originActivateAccount,
+  });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/seo/routes/graphql/LinkGraphql.tsx
+++ b/sample/outputs/with-origins/seo/routes/graphql/LinkGraphql.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternGraphql, UrlParamsGraphql, originGraphql } from "./patternGraphql";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsGraphql;
-export const LinkGraphql: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternGraphql, { path: {}, query, origin: origin ?? originGraphql });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsGraphql;
+};
+export const LinkGraphql: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternGraphql, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originGraphql });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/seo/routes/home/LinkHome.tsx
+++ b/sample/outputs/with-origins/seo/routes/home/LinkHome.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlParamsHome, patternNextJSHome } from "./patternHome";
-type LinkHomeProps = Omit<LinkProps, "href"> & UrlParamsHome;
-export const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
-  const { query = {}, ...rest } = props;
+type LinkHomeProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsHome };
+export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
   const path = {};
   const pathname = patternNextJSHome;
   const nextHref = {
@@ -14,5 +14,5 @@ export const LinkHome: React.FunctionComponent<LinkHomeProps> = (props) => {
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/with-origins/seo/routes/legacy/LinkLegacy.tsx
+++ b/sample/outputs/with-origins/seo/routes/legacy/LinkLegacy.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternLegacy, UrlParamsLegacy, originLegacy } from "./patternLegacy";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsLegacy;
-export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ query, origin, ...props }) => {
-  const to = generateUrl(patternLegacy, { path: {}, query, origin: origin ?? originLegacy });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams?: UrlParamsLegacy;
+};
+export const LinkLegacy: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams?.query, origin: urlParams?.origin ?? originLegacy });
   return <a {...props} href={to} />;
 };

--- a/sample/outputs/with-origins/seo/routes/terms/LinkTerms.tsx
+++ b/sample/outputs/with-origins/seo/routes/terms/LinkTerms.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import Link, { LinkProps } from "next/link";
 import { UrlParamsTerms, patternNextJSTerms } from "./patternTerms";
-type LinkTermsProps = Omit<LinkProps, "href"> & UrlParamsTerms;
-export const LinkTerms: React.FunctionComponent<LinkTermsProps> = (props) => {
-  const { query = {}, ...rest } = props;
+type LinkTermsProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsTerms };
+export const LinkTerms: React.FunctionComponent<LinkTermsProps> = ({ urlParams, ...props }) => {
+  const { query = {} } = urlParams;
   const path = {};
   const pathname = patternNextJSTerms;
   const nextHref = {
@@ -14,5 +14,5 @@ export const LinkTerms: React.FunctionComponent<LinkTermsProps> = (props) => {
       ...query,
     },
   };
-  return <Link {...rest} href={nextHref} />;
+  return <Link {...props} href={nextHref} />;
 };

--- a/sample/outputs/with-origins/seo/routes/user/LinkUser.tsx
+++ b/sample/outputs/with-origins/seo/routes/user/LinkUser.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 
 import { patternUser, UrlParamsUser, originUser } from "./patternUser";
-type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & UrlParamsUser;
-export const LinkUser: React.FunctionComponent<LinkProps> = ({ path, query, origin, ...props }) => {
-  const to = generateUrl(patternUser, { path: path, query, origin: origin ?? originUser });
+type LinkProps = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, "href"> & {
+  urlParams: UrlParamsUser;
+};
+export const LinkUser: React.FunctionComponent<LinkProps> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin ?? originUser });
   return <a {...props} href={to} />;
 };


### PR DESCRIPTION
This PR updates all Link components to receive one `urlParams` that contains all routing props. This would help reduce the chance of prop collision and make it easier to pass the `urlParams` props around