### PR TITLE
Standardise url params usage for redirect component

### DIFF
--- a/.changeset/pretty-planes-drop.md
+++ b/.changeset/pretty-planes-drop.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": minor
+---
+
+[Breaking change] Generated Redirect components now take urlParams

--- a/packages/core/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.test.ts
@@ -26,8 +26,8 @@ describe("generateRedirectFileDefault", () => {
         import RedirectServerSide from 'route-codegen/RedirectServerSide'
         import {generateUrl,} from 'route-codegen'
         import {UrlParamsLogin,patternLogin,originLogin,} from './patternLogin'
-        export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = props => {
-          const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin ?? originLogin });
+        export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode, urlParams?: UrlParamsLogin }> = ({ urlParams , ...props }) => {
+          const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLogin });
           return <RedirectServerSide href={to} fallback={props.fallback} />;
         };"
     `);
@@ -50,8 +50,8 @@ describe("generateRedirectFileDefault", () => {
         import RedirectServerSide from 'route-codegen/RedirectServerSide'
         import {generateUrl,} from 'route-codegen'
         import {UrlParamsLogin,patternLogin,originLogin,} from './patternLogin'
-        export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = props => {
-          const to = generateUrl(patternLogin, { path: props.path, query: props.query, origin: props.origin ?? originLogin });
+        export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode, urlParams: UrlParamsLogin }> = ({ urlParams , ...props }) => {
+          const to = generateUrl(patternLogin, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originLogin });
           return <RedirectServerSide href={to} fallback={props.fallback} />;
         };"
     `);

--- a/packages/core/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorDefault/generateRedirectFileDefault.ts
@@ -20,6 +20,9 @@ export const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultP
   const generateUrlFnName = "generateUrl"; // TODO: find a better way to reference this
   const redirectCompName = "RedirectServerSide"; // TODO: find a better way to reference this
 
+  const urlParamsModifier = hasPathParams ? "" : "?";
+  const urlParamsTemplate = `urlParams${urlParamsModifier}: ${patternNamedExports.urlParamsInterfaceName}`;
+
   const template = `${printImport({ defaultImport: "React", from: "react" })}
   ${printImport(importRedirectServerSide)}
   ${printImport(importGenerateUrl)}
@@ -31,12 +34,10 @@ export const generateRedirectFileDefault = (params: GenerateRedirectFileDefaultP
     ],
     from: `./${patternNamedExports.filename}`,
   })}
-  export const ${functionName}: React.FunctionComponent<${
-    patternNamedExports.urlParamsInterfaceName
-  } & { fallback?: React.ReactNode }> = props => {
+  export const ${functionName}: React.FunctionComponent<{ fallback?: React.ReactNode, ${urlParamsTemplate} }> = ({ urlParams , ...props }) => {
     const to = ${generateUrlFnName}(${patternNamedExports.patternName}, { path: ${
-    hasPathParams ? "props.path" : "{}"
-  }, query: props.query, origin: props.origin ?? ${patternNamedExports.originName} });
+    hasPathParams ? "urlParams.path" : "{}"
+  }, query: urlParams.query, origin: urlParams.origin ?? ${patternNamedExports.originName} });
     return <${redirectCompName} href={to} fallback={props.fallback} />;
   };`;
 

--- a/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.test.ts
@@ -25,8 +25,8 @@ describe("generateRedirectFileReactRouterV5", () => {
         import {generateUrl,} from 'route-codegen'
         import {Redirect,} from 'react-router'
         import {UrlParamsLogin,patternLogin,} from './patternLogin'
-        export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = props => {
-          const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin });
+        export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode, urlParams?: UrlParamsLogin }> = ({ urlParams, ...props }) => {
+          const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin });
           return (
             <>
               <Redirect to={to} />
@@ -54,8 +54,8 @@ describe("generateRedirectFileReactRouterV5", () => {
         import {generateUrl,} from 'route-codegen'
         import {Redirect,} from 'react-router'
         import {UrlParamsLogin,patternLogin,} from './patternLogin'
-        export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = props => {
-          const to = generateUrl(patternLogin, { path: props.path, query: props.query, origin: props.origin });
+        export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode, urlParams: UrlParamsLogin }> = ({ urlParams, ...props }) => {
+          const to = generateUrl(patternLogin, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin });
           return (
             <>
               <Redirect to={to} />

--- a/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
+++ b/packages/core/src/generate/generateAppFiles/generatorReactRouterV5/generateRedirectFileReactRouterV5.ts
@@ -18,6 +18,9 @@ export const generateRedirectFileReactRouterV5 = (params: GenerateRedirectFileRe
   const hasPathParams = !!patternNamedExports.pathParamsInterfaceName;
   const generateUrlFnName = "generateUrl"; // TODO: find a better way to reference this
 
+  const urlParamsModifier = hasPathParams ? "" : "?";
+  const urlParamsTemplate = `urlParams${urlParamsModifier}: ${patternNamedExports.urlParamsInterfaceName}`;
+
   const template = `${printImport({ defaultImport: "React", from: "react" })}
   ${printImport(importGenerateUrl)}
   ${printImport({ namedImports: [{ name: "Redirect" }], from: "react-router" })}
@@ -25,12 +28,10 @@ export const generateRedirectFileReactRouterV5 = (params: GenerateRedirectFileRe
     namedImports: [{ name: patternNamedExports.urlParamsInterfaceName }, { name: patternNamedExports.patternName }],
     from: `./${patternNamedExports.filename}`,
   })}
-  export const ${functionName}: React.FunctionComponent<${
-    patternNamedExports.urlParamsInterfaceName
-  } & { fallback?: React.ReactNode }> = props => {
+  export const ${functionName}: React.FunctionComponent<{ fallback?: React.ReactNode, ${urlParamsTemplate} }> = ({ urlParams, ...props }) => {
     const to = ${generateUrlFnName}(${patternNamedExports.patternName}, { path: ${
-    hasPathParams ? "props.path" : "{}"
-  }, query: props.query, origin: props.origin });
+    hasPathParams ? "urlParams.path" : "{}"
+  }, query: urlParams.query, origin: urlParams.origin });
     return (
       <>
         <Redirect to={to} />

--- a/sample/outputs/default/app/routes/about/RedirectAbout.tsx
+++ b/sample/outputs/default/app/routes/about/RedirectAbout.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAbout, patternAbout, originAbout } from "./patternAbout";
-export const RedirectAbout: React.FunctionComponent<UrlParamsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, { path: props.path, query: props.query, origin: props.origin ?? originAbout });
+export const RedirectAbout: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsAbout }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originAbout });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/account/RedirectAccount.tsx
+++ b/sample/outputs/default/app/routes/account/RedirectAccount.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { Redirect } from "react-router";
 import { UrlParamsAccount, patternAccount } from "./patternAccount";
-export const RedirectAccount: React.FunctionComponent<UrlParamsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, { path: {}, query: props.query, origin: props.origin });
+export const RedirectAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams.query, origin: urlParams.origin });
   return (
     <>
       <Redirect to={to} />

--- a/sample/outputs/default/app/routes/contact/RedirectContact.tsx
+++ b/sample/outputs/default/app/routes/contact/RedirectContact.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsContact, patternContact, originContact } from "./patternContact";
-export const RedirectContact: React.FunctionComponent<UrlParamsContact & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternContact, { path: props.path, query: props.query, origin: props.origin ?? originContact });
+export const RedirectContact: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsContact }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originContact });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/home/RedirectHome.tsx
+++ b/sample/outputs/default/app/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/default/app/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/login/RedirectLogin.tsx
+++ b/sample/outputs/default/app/routes/login/RedirectLogin.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLogin, patternLogin, originLogin } from "./patternLogin";
-export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin ?? originLogin });
+export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLogin }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLogin });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/signup/RedirectSignup.tsx
+++ b/sample/outputs/default/app/routes/signup/RedirectSignup.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsSignup, patternSignup, originSignup } from "./patternSignup";
-export const RedirectSignup: React.FunctionComponent<UrlParamsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, { path: {}, query: props.query, origin: props.origin ?? originSignup });
+export const RedirectSignup: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsSignup }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originSignup });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/toc/RedirectToc.tsx
+++ b/sample/outputs/default/app/routes/toc/RedirectToc.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsToc, patternToc, originToc } from "./patternToc";
-export const RedirectToc: React.FunctionComponent<UrlParamsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, { path: {}, query: props.query, origin: props.origin ?? originToc });
+export const RedirectToc: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsToc }> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originToc });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/app/routes/user/RedirectUser.tsx
+++ b/sample/outputs/default/app/routes/user/RedirectUser.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { Redirect } from "react-router";
 import { UrlParamsUser, patternUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin });
   return (
     <>
       <Redirect to={to} />

--- a/sample/outputs/default/auth/routes/about/RedirectAbout.tsx
+++ b/sample/outputs/default/auth/routes/about/RedirectAbout.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAbout, patternAbout, originAbout } from "./patternAbout";
-export const RedirectAbout: React.FunctionComponent<UrlParamsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, { path: props.path, query: props.query, origin: props.origin ?? originAbout });
+export const RedirectAbout: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsAbout }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originAbout });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/account/RedirectAccount.tsx
+++ b/sample/outputs/default/auth/routes/account/RedirectAccount.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAccount, patternAccount, originAccount } from "./patternAccount";
-export const RedirectAccount: React.FunctionComponent<UrlParamsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, { path: {}, query: props.query, origin: props.origin ?? originAccount });
+export const RedirectAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originAccount });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/contact/RedirectContact.tsx
+++ b/sample/outputs/default/auth/routes/contact/RedirectContact.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsContact, patternContact, originContact } from "./patternContact";
-export const RedirectContact: React.FunctionComponent<UrlParamsContact & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternContact, { path: props.path, query: props.query, origin: props.origin ?? originContact });
+export const RedirectContact: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsContact }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originContact });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/home/RedirectHome.tsx
+++ b/sample/outputs/default/auth/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/default/auth/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/login/RedirectLogin.tsx
+++ b/sample/outputs/default/auth/routes/login/RedirectLogin.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { Redirect } from "react-router";
 import { UrlParamsLogin, patternLogin } from "./patternLogin";
-export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin });
+export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLogin }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin });
   return (
     <>
       <Redirect to={to} />

--- a/sample/outputs/default/auth/routes/signup/RedirectSignup.tsx
+++ b/sample/outputs/default/auth/routes/signup/RedirectSignup.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { Redirect } from "react-router";
 import { UrlParamsSignup, patternSignup } from "./patternSignup";
-export const RedirectSignup: React.FunctionComponent<UrlParamsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, { path: {}, query: props.query, origin: props.origin });
+export const RedirectSignup: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsSignup }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams.query, origin: urlParams.origin });
   return (
     <>
       <Redirect to={to} />

--- a/sample/outputs/default/auth/routes/toc/RedirectToc.tsx
+++ b/sample/outputs/default/auth/routes/toc/RedirectToc.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsToc, patternToc, originToc } from "./patternToc";
-export const RedirectToc: React.FunctionComponent<UrlParamsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, { path: {}, query: props.query, origin: props.origin ?? originToc });
+export const RedirectToc: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsToc }> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originToc });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/auth/routes/user/RedirectUser.tsx
+++ b/sample/outputs/default/auth/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/about/RedirectAbout.tsx
+++ b/sample/outputs/default/seo-strict/routes/about/RedirectAbout.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAbout, patternAbout, originAbout } from "./patternAbout";
-export const RedirectAbout: React.FunctionComponent<UrlParamsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, { path: props.path, query: props.query, origin: props.origin ?? originAbout });
+export const RedirectAbout: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsAbout }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originAbout });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/account/RedirectAccount.tsx
+++ b/sample/outputs/default/seo-strict/routes/account/RedirectAccount.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAccount, patternAccount, originAccount } from "./patternAccount";
-export const RedirectAccount: React.FunctionComponent<UrlParamsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, { path: {}, query: props.query, origin: props.origin ?? originAccount });
+export const RedirectAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originAccount });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/home/RedirectHome.tsx
+++ b/sample/outputs/default/seo-strict/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/default/seo-strict/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/login/RedirectLogin.tsx
+++ b/sample/outputs/default/seo-strict/routes/login/RedirectLogin.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLogin, patternLogin, originLogin } from "./patternLogin";
-export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin ?? originLogin });
+export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLogin }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLogin });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/signup/RedirectSignup.tsx
+++ b/sample/outputs/default/seo-strict/routes/signup/RedirectSignup.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsSignup, patternSignup, originSignup } from "./patternSignup";
-export const RedirectSignup: React.FunctionComponent<UrlParamsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, { path: {}, query: props.query, origin: props.origin ?? originSignup });
+export const RedirectSignup: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsSignup }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originSignup });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/toc/RedirectToc.tsx
+++ b/sample/outputs/default/seo-strict/routes/toc/RedirectToc.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsToc, patternToc, originToc } from "./patternToc";
-export const RedirectToc: React.FunctionComponent<UrlParamsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, { path: {}, query: props.query, origin: props.origin ?? originToc });
+export const RedirectToc: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsToc }> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originToc });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo-strict/routes/user/RedirectUser.tsx
+++ b/sample/outputs/default/seo-strict/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/account/RedirectAccount.tsx
+++ b/sample/outputs/default/seo/routes/account/RedirectAccount.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAccount, patternAccount, originAccount } from "./patternAccount";
-export const RedirectAccount: React.FunctionComponent<UrlParamsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, { path: {}, query: props.query, origin: props.origin ?? originAccount });
+export const RedirectAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originAccount });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/contact/RedirectContact.tsx
+++ b/sample/outputs/default/seo/routes/contact/RedirectContact.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsContact, patternContact, originContact } from "./patternContact";
-export const RedirectContact: React.FunctionComponent<UrlParamsContact & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternContact, { path: props.path, query: props.query, origin: props.origin ?? originContact });
+export const RedirectContact: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsContact }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originContact });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/default/seo/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/login/RedirectLogin.tsx
+++ b/sample/outputs/default/seo/routes/login/RedirectLogin.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLogin, patternLogin, originLogin } from "./patternLogin";
-export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin ?? originLogin });
+export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLogin }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLogin });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/signup/RedirectSignup.tsx
+++ b/sample/outputs/default/seo/routes/signup/RedirectSignup.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsSignup, patternSignup, originSignup } from "./patternSignup";
-export const RedirectSignup: React.FunctionComponent<UrlParamsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, { path: {}, query: props.query, origin: props.origin ?? originSignup });
+export const RedirectSignup: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsSignup }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originSignup });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/toc/RedirectToc.tsx
+++ b/sample/outputs/default/seo/routes/toc/RedirectToc.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsToc, patternToc, originToc } from "./patternToc";
-export const RedirectToc: React.FunctionComponent<UrlParamsToc & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternToc, { path: {}, query: props.query, origin: props.origin ?? originToc });
+export const RedirectToc: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsToc }> = ({ urlParams, ...props }) => {
+  const to = generateUrl(patternToc, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originToc });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/seo/routes/user/RedirectUser.tsx
+++ b/sample/outputs/default/seo/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/about/RedirectAbout.tsx
+++ b/sample/outputs/default/toc/routes/about/RedirectAbout.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAbout, patternAbout, originAbout } from "./patternAbout";
-export const RedirectAbout: React.FunctionComponent<UrlParamsAbout & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAbout, { path: props.path, query: props.query, origin: props.origin ?? originAbout });
+export const RedirectAbout: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsAbout }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAbout, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originAbout });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/account/RedirectAccount.tsx
+++ b/sample/outputs/default/toc/routes/account/RedirectAccount.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsAccount, patternAccount, originAccount } from "./patternAccount";
-export const RedirectAccount: React.FunctionComponent<UrlParamsAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternAccount, { path: {}, query: props.query, origin: props.origin ?? originAccount });
+export const RedirectAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternAccount, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originAccount });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/contact/RedirectContact.tsx
+++ b/sample/outputs/default/toc/routes/contact/RedirectContact.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsContact, patternContact, originContact } from "./patternContact";
-export const RedirectContact: React.FunctionComponent<UrlParamsContact & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternContact, { path: props.path, query: props.query, origin: props.origin ?? originContact });
+export const RedirectContact: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsContact }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternContact, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originContact });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/home/RedirectHome.tsx
+++ b/sample/outputs/default/toc/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/default/toc/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/login/RedirectLogin.tsx
+++ b/sample/outputs/default/toc/routes/login/RedirectLogin.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLogin, patternLogin, originLogin } from "./patternLogin";
-export const RedirectLogin: React.FunctionComponent<UrlParamsLogin & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLogin, { path: {}, query: props.query, origin: props.origin ?? originLogin });
+export const RedirectLogin: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLogin }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLogin, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLogin });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/signup/RedirectSignup.tsx
+++ b/sample/outputs/default/toc/routes/signup/RedirectSignup.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsSignup, patternSignup, originSignup } from "./patternSignup";
-export const RedirectSignup: React.FunctionComponent<UrlParamsSignup & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternSignup, { path: {}, query: props.query, origin: props.origin ?? originSignup });
+export const RedirectSignup: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsSignup }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternSignup, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originSignup });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/default/toc/routes/user/RedirectUser.tsx
+++ b/sample/outputs/default/toc/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/outputs/with-origins/app/routes/activateAccount/RedirectActivateAccount.tsx
@@ -3,7 +3,14 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
-export const RedirectActivateAccount: React.FunctionComponent<UrlParamsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, { path: props.path, query: props.query, origin: props.origin ?? originActivateAccount });
+export const RedirectActivateAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsActivateAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternActivateAccount, {
+    path: urlParams.path,
+    query: urlParams.query,
+    origin: urlParams.origin ?? originActivateAccount,
+  });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/graphql/RedirectGraphql.tsx
+++ b/sample/outputs/with-origins/app/routes/graphql/RedirectGraphql.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
-export const RedirectGraphql: React.FunctionComponent<UrlParamsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, { path: {}, query: props.query, origin: props.origin ?? originGraphql });
+export const RedirectGraphql: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsGraphql }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternGraphql, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originGraphql });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/home/RedirectHome.tsx
+++ b/sample/outputs/with-origins/app/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/with-origins/app/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/terms/RedirectTerms.tsx
+++ b/sample/outputs/with-origins/app/routes/terms/RedirectTerms.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsTerms, patternTerms, originTerms } from "./patternTerms";
-export const RedirectTerms: React.FunctionComponent<UrlParamsTerms & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternTerms, { path: {}, query: props.query, origin: props.origin ?? originTerms });
+export const RedirectTerms: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsTerms }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternTerms, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originTerms });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/app/routes/user/RedirectUser.tsx
+++ b/sample/outputs/with-origins/app/routes/user/RedirectUser.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import { generateUrl } from "@route-codegen/utils";
 import { Redirect } from "react-router";
 import { UrlParamsUser, patternUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin });
   return (
     <>
       <Redirect to={to} />

--- a/sample/outputs/with-origins/seo/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/outputs/with-origins/seo/routes/activateAccount/RedirectActivateAccount.tsx
@@ -3,7 +3,14 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
-export const RedirectActivateAccount: React.FunctionComponent<UrlParamsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, { path: props.path, query: props.query, origin: props.origin ?? originActivateAccount });
+export const RedirectActivateAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsActivateAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternActivateAccount, {
+    path: urlParams.path,
+    query: urlParams.query,
+    origin: urlParams.origin ?? originActivateAccount,
+  });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/seo/routes/graphql/RedirectGraphql.tsx
+++ b/sample/outputs/with-origins/seo/routes/graphql/RedirectGraphql.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
-export const RedirectGraphql: React.FunctionComponent<UrlParamsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, { path: {}, query: props.query, origin: props.origin ?? originGraphql });
+export const RedirectGraphql: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsGraphql }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternGraphql, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originGraphql });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/seo/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/with-origins/seo/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/seo/routes/user/RedirectUser.tsx
+++ b/sample/outputs/with-origins/seo/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/activateAccount/RedirectActivateAccount.tsx
+++ b/sample/outputs/with-origins/server/routes/activateAccount/RedirectActivateAccount.tsx
@@ -3,7 +3,14 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsActivateAccount, patternActivateAccount, originActivateAccount } from "./patternActivateAccount";
-export const RedirectActivateAccount: React.FunctionComponent<UrlParamsActivateAccount & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternActivateAccount, { path: props.path, query: props.query, origin: props.origin ?? originActivateAccount });
+export const RedirectActivateAccount: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsActivateAccount }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternActivateAccount, {
+    path: urlParams.path,
+    query: urlParams.query,
+    origin: urlParams.origin ?? originActivateAccount,
+  });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/graphql/RedirectGraphql.tsx
+++ b/sample/outputs/with-origins/server/routes/graphql/RedirectGraphql.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsGraphql, patternGraphql, originGraphql } from "./patternGraphql";
-export const RedirectGraphql: React.FunctionComponent<UrlParamsGraphql & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternGraphql, { path: {}, query: props.query, origin: props.origin ?? originGraphql });
+export const RedirectGraphql: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsGraphql }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternGraphql, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originGraphql });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/home/RedirectHome.tsx
+++ b/sample/outputs/with-origins/server/routes/home/RedirectHome.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsHome, patternHome, originHome } from "./patternHome";
-export const RedirectHome: React.FunctionComponent<UrlParamsHome & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternHome, { path: {}, query: props.query, origin: props.origin ?? originHome });
+export const RedirectHome: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsHome }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternHome, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originHome });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/legacy/RedirectLegacy.tsx
+++ b/sample/outputs/with-origins/server/routes/legacy/RedirectLegacy.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsLegacy, patternLegacy, originLegacy } from "./patternLegacy";
-export const RedirectLegacy: React.FunctionComponent<UrlParamsLegacy & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternLegacy, { path: {}, query: props.query, origin: props.origin ?? originLegacy });
+export const RedirectLegacy: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsLegacy }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternLegacy, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originLegacy });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/terms/RedirectTerms.tsx
+++ b/sample/outputs/with-origins/server/routes/terms/RedirectTerms.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsTerms, patternTerms, originTerms } from "./patternTerms";
-export const RedirectTerms: React.FunctionComponent<UrlParamsTerms & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternTerms, { path: {}, query: props.query, origin: props.origin ?? originTerms });
+export const RedirectTerms: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams?: UrlParamsTerms }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternTerms, { path: {}, query: urlParams.query, origin: urlParams.origin ?? originTerms });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };

--- a/sample/outputs/with-origins/server/routes/user/RedirectUser.tsx
+++ b/sample/outputs/with-origins/server/routes/user/RedirectUser.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { RedirectServerSide } from "@route-codegen/react";
 import { generateUrl } from "@route-codegen/utils";
 import { UrlParamsUser, patternUser, originUser } from "./patternUser";
-export const RedirectUser: React.FunctionComponent<UrlParamsUser & { fallback?: React.ReactNode }> = (props) => {
-  const to = generateUrl(patternUser, { path: props.path, query: props.query, origin: props.origin ?? originUser });
+export const RedirectUser: React.FunctionComponent<{ fallback?: React.ReactNode; urlParams: UrlParamsUser }> = ({
+  urlParams,
+  ...props
+}) => {
+  const to = generateUrl(patternUser, { path: urlParams.path, query: urlParams.query, origin: urlParams.origin ?? originUser });
   return <RedirectServerSide href={to} fallback={props.fallback} />;
 };


### PR DESCRIPTION
This updates the `Redirect` components to use `urlParams`, similar to `Link` components