### PR TITLE
Update next js plugin link template

### DIFF
--- a/.changeset/wise-dodos-shop.md
+++ b/.changeset/wise-dodos-shop.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": patch
+---
+
+Update TypescriptNextJSPlugin to handle new next LInk API

--- a/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
@@ -46,20 +46,12 @@ describe("TypescriptNextJSPlugin - Link file", () => {
     expect(templateFile.template).toMatchInlineSnapshot(`
       "import React from 'react'
           import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
-          import {UrlParamsLogin,patternNextJSLogin,} from './patternLogin'
+          import {generateUrl,} from 'route-codegen'
+          import {UrlParamsLogin,patternLogin,} from './patternLogin'
           type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & { urlParams?: UrlParamsLogin }
           export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
-            const query = urlParams?.query || {};
-            const path = {};
-            const pathname = patternNextJSLogin;
-            const nextHref = {
-              pathname: pathname,
-              query: {
-                ...path,
-                ...query,
-              },
-            }
-            return <Link {...props} customHref={nextHref} />;
+            const href = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+            return <Link {...props} customHref={href} />;
           }"
     `);
   });
@@ -80,20 +72,12 @@ describe("TypescriptNextJSPlugin - Link file", () => {
     expect(templateFile.template).toMatchInlineSnapshot(`
       "import React from 'react'
           import Link, {NextJSLinkProps,} from 'src/NextJS/Link'
-          import {UrlParamsLogin,patternNextJSLogin,possiblePathParamsLogin,} from './patternLogin'
+          import {generateUrl,} from 'route-codegen'
+          import {UrlParamsLogin,patternLogin,} from './patternLogin'
           type LinkLoginProps = Omit<NextJSLinkProps, 'customHref'> & { urlParams: UrlParamsLogin }
           export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
-            const query = urlParams?.query || {};
-            const path = urlParams.path;
-            const pathname = possiblePathParamsLogin.filter((key) => !(key in path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[\${suppliedParam}]\`, \\"\\"), patternNextJSLogin);
-            const nextHref = {
-              pathname: pathname,
-              query: {
-                ...path,
-                ...query,
-              },
-            }
-            return <Link {...props} customHref={nextHref} />;
+            const href = generateUrl(patternLogin, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+            return <Link {...props} customHref={href} />;
           }"
     `);
   });
@@ -123,20 +107,12 @@ describe("TypescriptNextJSPlugin - Link file", () => {
     expect(templateFile.template).toMatchInlineSnapshot(`
       "import React from 'react'
           import {CustomLinkProps,CustomLink as Link,} from 'src/common/Link'
-          import {UrlParamsLogin,patternNextJSLogin,} from './patternLogin'
+          import {generateUrl,} from 'route-codegen'
+          import {UrlParamsLogin,patternLogin,} from './patternLogin'
           type LinkLoginProps = Omit<CustomLinkProps, 'to'> & { urlParams?: UrlParamsLogin }
           export const LinkLogin: React.FunctionComponent<LinkLoginProps> = ({ urlParams, ...props}) => {
-            const query = urlParams?.query || {};
-            const path = {};
-            const pathname = patternNextJSLogin;
-            const nextHref = {
-              pathname: pathname,
-              query: {
-                ...path,
-                ...query,
-              },
-            }
-            return <Link {...props} to={nextHref} />;
+            const href = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+            return <Link {...props} to={href} />;
           }"
     `);
   });

--- a/sample/outputs/default/seo-strict/routes/contact/LinkContact.tsx
+++ b/sample/outputs/default/seo-strict/routes/contact/LinkContact.tsx
@@ -1,20 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { LinkProps } from "next/link";
-import { UrlParamsContact, patternNextJSContact, possilePathParamsContact } from "./patternContact";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsContact, patternContact } from "./patternContact";
 type LinkContactProps = Omit<LinkProps, "href"> & { urlParams: UrlParamsContact };
 export const LinkContact: React.FunctionComponent<LinkContactProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = urlParams.path;
-  const pathname = possilePathParamsContact
-    .filter((key) => !(key in path))
-    .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSContact);
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };

--- a/sample/outputs/default/seo/routes/about/LinkAbout.tsx
+++ b/sample/outputs/default/seo/routes/about/LinkAbout.tsx
@@ -1,20 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { LinkProps } from "next/link";
-import { UrlParamsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsAbout, patternAbout } from "./patternAbout";
 type LinkAboutProps = Omit<LinkProps, "href"> & { urlParams: UrlParamsAbout };
 export const LinkAbout: React.FunctionComponent<LinkAboutProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = urlParams.path;
-  const pathname = possilePathParamsAbout
-    .filter((key) => !(key in path))
-    .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };

--- a/sample/outputs/default/seo/routes/home/LinkHome.tsx
+++ b/sample/outputs/default/seo/routes/home/LinkHome.tsx
@@ -1,18 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { LinkProps } from "next/link";
-import { UrlParamsHome, patternNextJSHome } from "./patternHome";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsHome, patternHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsHome };
 export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = {};
-  const pathname = patternNextJSHome;
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };

--- a/sample/outputs/default/toc/routes/toc/LinkToc.tsx
+++ b/sample/outputs/default/toc/routes/toc/LinkToc.tsx
@@ -1,18 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { NextLinkProps } from "~/common/components/NextLink";
-import { UrlParamsToc, patternNextJSToc } from "./patternToc";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsToc, patternToc } from "./patternToc";
 type LinkTocProps = Omit<NextLinkProps, "href"> & { urlParams?: UrlParamsToc };
 export const LinkToc: React.FunctionComponent<LinkTocProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = {};
-  const pathname = patternNextJSToc;
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };

--- a/sample/outputs/with-origins/seo/routes/home/LinkHome.tsx
+++ b/sample/outputs/with-origins/seo/routes/home/LinkHome.tsx
@@ -1,18 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { LinkProps } from "next/link";
-import { UrlParamsHome, patternNextJSHome } from "./patternHome";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsHome, patternHome } from "./patternHome";
 type LinkHomeProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsHome };
 export const LinkHome: React.FunctionComponent<LinkHomeProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = {};
-  const pathname = patternNextJSHome;
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };

--- a/sample/outputs/with-origins/seo/routes/terms/LinkTerms.tsx
+++ b/sample/outputs/with-origins/seo/routes/terms/LinkTerms.tsx
@@ -1,18 +1,10 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import React from "react";
 import Link, { LinkProps } from "next/link";
-import { UrlParamsTerms, patternNextJSTerms } from "./patternTerms";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsTerms, patternTerms } from "./patternTerms";
 type LinkTermsProps = Omit<LinkProps, "href"> & { urlParams?: UrlParamsTerms };
 export const LinkTerms: React.FunctionComponent<LinkTermsProps> = ({ urlParams, ...props }) => {
-  const query = urlParams?.query || {};
-  const path = {};
-  const pathname = patternNextJSTerms;
-  const nextHref = {
-    pathname: pathname,
-    query: {
-      ...path,
-      ...query,
-    },
-  };
-  return <Link {...props} href={nextHref} />;
+  const href = generateUrl(patternTerms, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+  return <Link {...props} href={href} />;
 };


### PR DESCRIPTION
Next JS plugin seemed to be using old API. This updates it to use href string as mentioned in https://nextjs.org/docs/api-reference/next/link#if-the-route-has-dynamic-segments