### PR TITLE
Deprecate NextJS templates in pattern plugin

### DIFF
--- a/.changeset/fifty-ties-sip.md
+++ b/.changeset/fifty-ties-sip.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": patch
+---
+
+Deprecate handling of NextJS patterns in pattern plugin. Update NextJS template files

--- a/packages/core/src/generate/generateAppFiles/generateTemplateFiles.ts
+++ b/packages/core/src/generate/generateAppFiles/generateTemplateFiles.ts
@@ -44,13 +44,6 @@ const generateTemplateFiles = async (params: GenerateTemplateFilesParams): Promi
     return [];
   }
 
-  // TODO: this is a hack to inject NextJS pattern into pattern file and should be removed
-  let linkOptionModeNextJS: "strict" | "loose" | undefined = undefined;
-  const routeInternal = pluginHelpers.findFirstOfType(pluginModules, "route-internal") as PluginModule | undefined;
-  if (routingType === "route-internal" && routeInternal?.plugin.isNextJS) {
-    linkOptionModeNextJS = (routeInternal.config?.mode || "loose") as "strict" | "loose"; // TODO: handle this!
-  }
-
   // TODO: type this better to scale
   const patternPlugin = pluginHelpers.findFirstOfType(pluginModules, "pattern") as
     | PluginModule<WithExtraConfig<PatternPluginBaseConfig, Record<string, unknown>>, PatternTemplateFile>
@@ -68,7 +61,6 @@ const generateTemplateFiles = async (params: GenerateTemplateFilesParams): Promi
     routePattern,
     destinationDir,
     extraConfig: patternPlugin.config,
-    linkOptionModeNextJS, // TODO: this is the NextJS pattern hack and should be removed
   });
   files.push(patternFile);
 

--- a/packages/core/src/plugins/typescript-anchor/TypescriptAnchorPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-anchor/TypescriptAnchorPlugin.test.ts
@@ -23,7 +23,6 @@ describe("TypescriptAnchorPlugin - LinkFile", () => {
       filename: "patternLogin",
       patternName: "patternLogin",
       urlParamsInterfaceName: "UrlParamsLogin",
-      patternNameNextJS: "patternNextJSLogin",
     },
     destinationDir: "path/to/routes",
     importGenerateUrl: { namedImports: [{ name: "generateUrl" }], from: "route-codegen" },
@@ -159,7 +158,6 @@ describe("TypescriptAnchorPlugin - RedirectFile", () => {
       filename: "patternLogin",
       patternName: "patternLogin",
       urlParamsInterfaceName: "UrlParamsLogin",
-      patternNameNextJS: "patternNextJSLogin",
     },
     destinationDir: "path/to/routes",
     extraConfig: {

--- a/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
@@ -30,7 +30,6 @@ describe("TypescriptNextJSPlugin - Link file", () => {
       filename: "patternLogin",
       patternName: "patternLogin",
       urlParamsInterfaceName: "UrlParamsLogin",
-      patternNameNextJS: "patternNextJSLogin",
     },
     destinationDir: "path/to/routes",
     importGenerateUrl: { namedImports: [{ name: "generateUrl" }], from: "route-codegen" },
@@ -62,7 +61,6 @@ describe("TypescriptNextJSPlugin - Link file", () => {
       patternNamedExports: {
         ...defaultParams.patternNamedExports,
         pathParamsInterfaceName: "PathParamsLogin",
-        possiblePathParamsVariableName: "possiblePathParamsLogin",
       },
     });
 
@@ -116,32 +114,6 @@ describe("TypescriptNextJSPlugin - Link file", () => {
           }"
     `);
   });
-
-  it("should throw error if no patternNameNextJS", () => {
-    expect(() =>
-      plugin.generate({
-        ...defaultParams,
-        extraConfig: {
-          importCustomLink: {
-            from: "src/common/Link",
-            componentNamedImport: "CustomLink",
-            propsNamedImport: "CustomLinkProps",
-            hrefProp: "to",
-          },
-          generate: {
-            linkComponent: true,
-            useParams: true,
-            useRedirect: true,
-          },
-          mode: "loose",
-        },
-        patternNamedExports: {
-          ...defaultParams.patternNamedExports,
-          patternNameNextJS: undefined,
-        },
-      })
-    ).toThrowError('[ERROR] Missing "patternNameNextJS". This is most likely a problem with route-codegen.');
-  });
 });
 
 describe("TypescriptNextJSPlugin - UseParams file", () => {
@@ -159,8 +131,7 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
         filename: "patternUser",
         patternName: "patternUser",
         urlParamsInterfaceName: "UrlParamsUser",
-        patternNameNextJS: "patternNextJSUser",
-        pathParamsInterfaceNameNextJS: "PathParamsNextJSUser",
+        pathParamsInterfaceName: "PathParamsUser",
       },
       destinationDir: "path/to/routes",
       routeName: "User",
@@ -187,9 +158,9 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
     expect(templateFile.extension).toBe(".ts");
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
-      "import {PathParamsNextJSUser,} from './patternUser'
+      "import {PathParamsUser,} from './patternUser'
             import {useRouter,} from 'next/router'
-            export const useParamsUser = (): PathParamsNextJSUser => {
+            export const useParamsUser = (): PathParamsUser => {
               const query = useRouter().query;
               return {id: query.id ?? '',subview: query.subview ?? '',singleEnum: query.singleEnum ?? '',optional: query.optional ? query.optional : undefined,optionalEnum: query.optionalEnum ? query.optionalEnum : undefined,};
             }"
@@ -210,8 +181,7 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
         filename: "patternUser",
         patternName: "patternUser",
         urlParamsInterfaceName: "UrlParamsUser",
-        patternNameNextJS: "patternNextJSUser",
-        pathParamsInterfaceNameNextJS: "PathParamsNextJSUser",
+        pathParamsInterfaceName: "PathParamsUser",
       },
       destinationDir: "path/to/routes",
       routeName: "User",
@@ -238,26 +208,26 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
     expect(templateFile.extension).toBe(".ts");
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
-      "import {PathParamsNextJSUser,} from './patternUser'
+      "import {PathParamsUser,} from './patternUser'
             import {useRouter,} from 'next/router'
-            export const useParamsUser = (): PathParamsNextJSUser => {
+            export const useParamsUser = (): PathParamsUser => {
               const query = useRouter().query;
-              return {id: query.id as PathParamsNextJSUser[\\"id\\"],
+              return {id: query.id as PathParamsUser[\\"id\\"],
       subview: (() => {
                       const subviewPossibleValues = [\\"profile\\",\\"pictures\\",]
                       if(subviewPossibleValues.findIndex((v) => v === query.subview) === -1){ throw new Error(\\"Unable to match 'subview' with expected enums\\"); }
-                      return query.subview as PathParamsNextJSUser[\\"subview\\"]
+                      return query.subview as PathParamsUser[\\"subview\\"]
                     })(),
       singleEnum: (() => {
                       const singleEnumPossibleValues = [\\"only\\",]
                       if(singleEnumPossibleValues.findIndex((v) => v === query.singleEnum) === -1){ throw new Error(\\"Unable to match 'singleEnum' with expected enums\\"); }
-                      return query.singleEnum as PathParamsNextJSUser[\\"singleEnum\\"]
+                      return query.singleEnum as PathParamsUser[\\"singleEnum\\"]
                     })(),
-      optional: query.optional ? (query.optional as PathParamsNextJSUser[\\"optional\\"]) : undefined,
+      optional: query.optional ? (query.optional as PathParamsUser[\\"optional\\"]) : undefined,
       optionalEnum: (() => {
                       const optionalEnumPossibleValues = [\\"enum1\\",\\"enum2\\",undefined,]
                       if(optionalEnumPossibleValues.findIndex((v) => v === query.optionalEnum) === -1){ throw new Error(\\"Unable to match 'optionalEnum' with expected enums\\"); }
-                      return query.optionalEnum as PathParamsNextJSUser[\\"optionalEnum\\"]
+                      return query.optionalEnum as PathParamsUser[\\"optionalEnum\\"]
                     })(),};
             }"
     `);
@@ -295,7 +265,6 @@ describe("TypescriptNextJSPlugin - UseRedirect file", () => {
         filename: "patternLogin",
         patternName: "patternLogin",
         urlParamsInterfaceName: "UrlParamsLogin",
-        patternNameNextJS: "patternNextJSLogin",
       },
       destinationDir: "path/to/routes",
       importGenerateUrl: { from: "route-codegen", namedImports: [{ name: "generateUrl" }] },
@@ -307,21 +276,14 @@ describe("TypescriptNextJSPlugin - UseRedirect file", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
       "import {useRouter,} from 'next/router'
-          import {UrlParamsLogin,patternNextJSLogin,} from './patternLogin'
+          import {generateUrl,} from 'route-codegen'
+          import {UrlParamsLogin,patternLogin,} from './patternLogin'
           export type RedirectFnLogin = (urlParams?: UrlParamsLogin) => void;
           export const useRedirectLogin = (): RedirectFnLogin => {
             const router = useRouter();
-            const redirect: RedirectFnLogin = urlParams => {
-              const query = urlParams?.query ?? {};
-              const path = {};
-              const pathname = patternNextJSLogin;
-              router.push({
-                pathname: pathname,
-                query: {
-                  ...path,
-                  ...query,
-                },
-              })
+            const redirect: RedirectFnLogin = (urlParams) => {
+              const href = generateUrl(patternLogin, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+              router.push(href);
             }
             return redirect;
           }"
@@ -359,8 +321,6 @@ describe("TypescriptNextJSPlugin - UseRedirect file", () => {
         patternName: "patternUserInfo",
         urlParamsInterfaceName: "UrlParamsUserInfo",
         pathParamsInterfaceName: "PathParamsUserInfo",
-        patternNameNextJS: "patternNextJSUserInfo",
-        possiblePathParamsVariableName: "possiblePathParamsUserInfo",
       },
       destinationDir: "path/to/routes",
       importGenerateUrl: { from: "route-codegen", namedImports: [{ name: "generateUrl" }] },
@@ -373,21 +333,14 @@ describe("TypescriptNextJSPlugin - UseRedirect file", () => {
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
       "import {useRouter,} from 'next/router'
-          import {UrlParamsUserInfo,patternNextJSUserInfo,possiblePathParamsUserInfo,} from './patternUserInfo'
+          import {generateUrl,} from 'route-codegen'
+          import {UrlParamsUserInfo,patternUserInfo,} from './patternUserInfo'
           export type RedirectFnUserInfo = (urlParams: UrlParamsUserInfo) => void;
           export const useRedirectUserInfo = (): RedirectFnUserInfo => {
             const router = useRouter();
-            const redirect: RedirectFnUserInfo = urlParams => {
-              const query = urlParams?.query ?? {};
-              const path = urlParams.path;
-              const pathname = possiblePathParamsUserInfo.filter((key) => !(key in urlParams.path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[\${suppliedParam}]\`, \\"\\"), patternNextJSUserInfo);
-              router.push({
-                pathname: pathname,
-                query: {
-                  ...path,
-                  ...query,
-                },
-              })
+            const redirect: RedirectFnUserInfo = (urlParams) => {
+              const href = generateUrl(patternUserInfo, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+              router.push(href);
             }
             return redirect;
           }"

--- a/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.test.ts
@@ -158,9 +158,10 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
     expect(templateFile.extension).toBe(".ts");
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
-      "import {PathParamsUser,} from './patternUser'
-            import {useRouter,} from 'next/router'
-            export const useParamsUser = (): PathParamsUser => {
+      "import {useRouter,} from 'next/router'
+            
+            interface PathParamsNextJSUser {id: string | string[];subview: string | string[];singleEnum: string | string[];optional?: string | string[];optionalEnum?: string | string[];}
+            export const useParamsUser = (): PathParamsNextJSUser => {
               const query = useRouter().query;
               return {id: query.id ?? '',subview: query.subview ?? '',singleEnum: query.singleEnum ?? '',optional: query.optional ? query.optional : undefined,optionalEnum: query.optionalEnum ? query.optionalEnum : undefined,};
             }"
@@ -208,8 +209,9 @@ describe("TypescriptNextJSPlugin - UseParams file", () => {
     expect(templateFile.extension).toBe(".ts");
     expect(templateFile.destinationDir).toBe("path/to/routes");
     expect(templateFile.template).toMatchInlineSnapshot(`
-      "import {PathParamsUser,} from './patternUser'
-            import {useRouter,} from 'next/router'
+      "import {useRouter,} from 'next/router'
+            import {PathParamsUser,} from './patternUser'
+            
             export const useParamsUser = (): PathParamsUser => {
               const query = useRouter().query;
               return {id: query.id as PathParamsUser[\\"id\\"],

--- a/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.ts
+++ b/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.ts
@@ -265,7 +265,7 @@ class TypescriptNextJSGenerator extends BaseRouteGenerator<ParsedLinkOptionsNext
     }
 
     const pathParamsInterfaceName = `PathParamsNextJS${routeName}`;
-    let template = `export interface ${pathParamsInterfaceName} {`;
+    let template = `interface ${pathParamsInterfaceName} {`;
     keys.forEach((key) => {
       // TODO: check if NextJS support optional param?
       const fieldName = `${key.name}${keyHelpers.isOptional(key) ? "?" : ""}`;

--- a/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.ts
+++ b/packages/core/src/plugins/typescript-next-js/TypescriptNextJSPlugin.ts
@@ -82,15 +82,7 @@ class TypescriptNextJSGenerator extends BaseRouteGenerator<ParsedLinkOptionsNext
     const {
       routeName: originalRouteName,
       destinationDir,
-      patternNamedExports: {
-        patternName,
-        filename: routePatternFilename,
-        pathParamsInterfaceName,
-        urlParamsInterfaceName,
-        // TODO: handle these 2. Possible full deprecation
-        // patternNameNextJS,
-        // possiblePathParamsVariableName,
-      },
+      patternNamedExports: { patternName, filename: routePatternFilename, pathParamsInterfaceName, urlParamsInterfaceName },
       importGenerateUrl,
     } = this.config;
 
@@ -237,68 +229,43 @@ class TypescriptNextJSGenerator extends BaseRouteGenerator<ParsedLinkOptionsNext
     };
   }
 
-  private _checkPathParamsInterfaceName():
-    | { type: "none" }
-    | { type: "normal"; pathParamsInterfaceName: string }
-    | { type: "nextJS"; pathParamsInterfaceName: string } {
+  private _checkPathParamsInterfaceName(): { type: "none" } | { type: "normal"; pathParamsInterfaceName: string } {
     const { patternNamedExports } = this.config;
 
-    if (patternNamedExports.pathParamsInterfaceNameNextJS) {
-      return { type: "nextJS", pathParamsInterfaceName: patternNamedExports.pathParamsInterfaceNameNextJS };
-    }
     if (patternNamedExports.pathParamsInterfaceName) {
       return { type: "normal", pathParamsInterfaceName: patternNamedExports.pathParamsInterfaceName };
     }
+
     return { type: "none" };
   }
 
   private _generateUseRedirectFile(): TemplateFile {
     const {
       routeName: originalRouteName,
-      patternNamedExports: {
-        pathParamsInterfaceName,
-        filename: routePatternFilename,
-        urlParamsInterfaceName,
-        patternNameNextJS,
-        possiblePathParamsVariableName,
-      },
+      patternNamedExports: { patternName, pathParamsInterfaceName, filename: routePatternFilename, urlParamsInterfaceName },
       destinationDir,
+      importGenerateUrl,
     } = this.config;
-
-    if (!patternNameNextJS) {
-      return throwError([], 'Missing "patternNameNextJS". This is most likely a problem with route-codegen.');
-    }
 
     const routeName = capitalizeFirstChar(originalRouteName);
 
     const functionName = `useRedirect${routeName}`;
-    const pathVariable = pathParamsInterfaceName ? "urlParams.path" : "{}";
     const urlParamsModifier = pathParamsInterfaceName ? "" : "?";
     const resultTypeInterface = `RedirectFn${routeName}`;
-
-    const namedImportsFromPatternFile = [{ name: urlParamsInterfaceName }, { name: patternNameNextJS }];
-    let pathnameTemplate = `const pathname = ${patternNameNextJS};`;
-    if (possiblePathParamsVariableName) {
-      namedImportsFromPatternFile.push({ name: possiblePathParamsVariableName });
-      pathnameTemplate = `const pathname = ${possiblePathParamsVariableName}.filter((key) => !(key in urlParams.path)).reduce((prevPattern, suppliedParam) => prevPattern.replace(\`/[${"${suppliedParam"}}]\`, ""), ${patternNameNextJS});`;
-    }
+    const hasPathParams = !!pathParamsInterfaceName;
+    const generateUrlFnName = "generateUrl"; // TODO: find a better way to reference this
 
     const template = `${printImport({ namedImports: [{ name: "useRouter" }], from: "next/router" })}
-    ${printImport({ namedImports: namedImportsFromPatternFile, from: `./${routePatternFilename}` })}
+    ${printImport(importGenerateUrl)}
+    ${printImport({ namedImports: [{ name: urlParamsInterfaceName }, { name: patternName }], from: `./${routePatternFilename}` })}
     export type ${resultTypeInterface} = (urlParams${urlParamsModifier}: ${urlParamsInterfaceName}) => void;
     export const ${functionName} = (): ${resultTypeInterface} => {
       const router = useRouter();
-      const redirect: ${resultTypeInterface} = urlParams => {
-        const query = urlParams?.query ?? {};
-        const path = ${pathVariable};
-        ${pathnameTemplate}
-        router.push({
-          pathname: pathname,
-          query: {
-            ...path,
-            ...query,
-          },
-        })
+      const redirect: ${resultTypeInterface} = (urlParams) => {
+        const href = ${generateUrlFnName}(${patternName}, { path: ${
+      hasPathParams ? "urlParams.path" : "{}"
+    }, query: urlParams?.query, origin: urlParams?.origin });
+        router.push(href);
       }
       return redirect;
     }`;
@@ -377,7 +344,6 @@ class TypescriptNextJSGenerator extends BaseRouteGenerator<ParsedLinkOptionsNext
 
 export const plugin: GeneralCodegenPlugin<ExtraConfig> = {
   type: "route-internal",
-  isNextJS: true,
   generate: (config) => {
     return new TypescriptNextJSGenerator(config).generate();
   },

--- a/packages/core/src/plugins/typescript-pattern/TypescriptPatternPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-pattern/TypescriptPatternPlugin.test.ts
@@ -1,7 +1,7 @@
 import { plugin } from "./TypescriptPatternPlugin";
 
 describe("TypescriptPatternPlugin", () => {
-  describe("Default and ReactRouterV5", () => {
+  describe("No origin", () => {
     it("should generate correctly if no dynamic path", () => {
       const templateFile = plugin.generate({
         origin: "",
@@ -9,7 +9,6 @@ describe("TypescriptPatternPlugin", () => {
         routePattern: "/app/login",
         destinationDir: "path/to/routes",
         routeName: "Login",
-        linkOptionModeNextJS: undefined,
       });
 
       expect(templateFile.type).toBe("pattern");
@@ -36,7 +35,6 @@ describe("TypescriptPatternPlugin", () => {
         routePattern: "/app/users/:id/:subview(profile|pictures)",
         destinationDir: "path/to/routes",
         routeName: "UserInfo",
-        linkOptionModeNextJS: undefined,
       });
 
       expect(templateFile.type).toBe("pattern");
@@ -50,10 +48,7 @@ describe("TypescriptPatternPlugin", () => {
       expect(templateFile.template).toMatchInlineSnapshot(`
         "export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
             export const originUserInfo = ''
-            
             export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
-            
-            export const possilePathParamsUserInfo = ['id','subview',]
             export interface UrlParamsUserInfo {
               path: PathParamsUserInfo;
               query?: Record<string, string | undefined>;
@@ -66,150 +61,6 @@ describe("TypescriptPatternPlugin", () => {
         pathParamsInterfaceName: "PathParamsUserInfo",
         urlParamsInterfaceName: "UrlParamsUserInfo",
         filename: "patternUserInfo",
-        possiblePathParamsVariableName: "possilePathParamsUserInfo",
-      });
-    });
-  });
-
-  describe("NextJS", () => {
-    it("should generate template correctly with loose NextJS pattern", () => {
-      const templateFile = plugin.generate({
-        routingType: "route-internal",
-        origin: "",
-        routePattern: "/app/users/:id/:subview(profile|pictures)/:singleEnum(only)/:optional?/:optionalEnum(enum1|enum2)?",
-        destinationDir: "path/to/routes",
-        routeName: "UserInfo",
-        linkOptionModeNextJS: "loose",
-      });
-
-      expect(templateFile.type).toBe("pattern");
-      expect(templateFile.hasDefaultExport).toBe(false);
-      expect(templateFile.hasNamedExports).toBe(true);
-      expect(templateFile.routeName).toBe("UserInfo");
-      expect(templateFile.routingType).toBe("route-internal");
-      expect(templateFile.filename).toBe("patternUserInfo");
-      expect(templateFile.extension).toBe(".ts");
-      expect(templateFile.destinationDir).toBe("path/to/routes");
-      expect(templateFile.template).toMatchInlineSnapshot(`
-        "export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)/:singleEnum(only)/:optional?/:optionalEnum(enum1|enum2)?'
-            export const originUserInfo = ''
-            /** Recommended file paths:
-             * - \\"src/pages/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]/index.tsx\\"
-             * - \\"pages/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]/index.tsx\\"
-             */
-            export const patternNextJSUserInfo = \\"/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]\\"
-            export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';singleEnum:'only';optional?: string;optionalEnum?:'enum1'|'enum2';}
-            export interface PathParamsNextJSUserInfo {id: string | string[];subview: string | string[];singleEnum: string | string[];optional?: string | string[];optionalEnum?: string | string[];}
-            export const possilePathParamsUserInfo = ['id','subview','singleEnum','optional','optionalEnum',]
-            export interface UrlParamsUserInfo {
-              path: PathParamsUserInfo;
-              query?: Record<string, string | undefined>;
-              origin?: string;
-            }"
-      `);
-      expect(templateFile.namedExports).toEqual({
-        originName: "originUserInfo",
-        patternName: "patternUserInfo",
-        patternNameNextJS: "patternNextJSUserInfo",
-        pathParamsInterfaceName: "PathParamsUserInfo",
-        pathParamsInterfaceNameNextJS: "PathParamsNextJSUserInfo",
-        urlParamsInterfaceName: "UrlParamsUserInfo",
-        filename: "patternUserInfo",
-        possiblePathParamsVariableName: "possilePathParamsUserInfo",
-      });
-    });
-
-    it("should generate template correctly with strict NextJS pattern", () => {
-      const templateFile = plugin.generate({
-        routingType: "route-internal",
-        origin: "",
-        routePattern: "/app/users/:id/:subview(profile|pictures)/:singleEnum(only)/:optional?/:optionalEnum(enum1|enum2)?",
-        destinationDir: "path/to/routes",
-        routeName: "UserInfo",
-        linkOptionModeNextJS: "strict",
-      });
-
-      expect(templateFile.type).toBe("pattern");
-      expect(templateFile.hasDefaultExport).toBe(false);
-      expect(templateFile.hasNamedExports).toBe(true);
-      expect(templateFile.routeName).toBe("UserInfo");
-      expect(templateFile.routingType).toBe("route-internal");
-      expect(templateFile.filename).toBe("patternUserInfo");
-      expect(templateFile.extension).toBe(".ts");
-      expect(templateFile.destinationDir).toBe("path/to/routes");
-      expect(templateFile.template).toMatchInlineSnapshot(`
-        "export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)/:singleEnum(only)/:optional?/:optionalEnum(enum1|enum2)?'
-            export const originUserInfo = ''
-            /** Recommended file paths:
-             * - \\"src/pages/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]/index.tsx\\"
-             * - \\"pages/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]/index.tsx\\"
-             */
-            export const patternNextJSUserInfo = \\"/app/users/[id]/[subview]/[singleEnum]/[optional]/[optionalEnum]\\"
-            export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';singleEnum:'only';optional?: string;optionalEnum?:'enum1'|'enum2';}
-            
-            export const possilePathParamsUserInfo = ['id','subview','singleEnum','optional','optionalEnum',]
-            export interface UrlParamsUserInfo {
-              path: PathParamsUserInfo;
-              query?: Record<string, string | undefined>;
-              origin?: string;
-            }"
-      `);
-      expect(templateFile.namedExports).toEqual({
-        originName: "originUserInfo",
-        patternName: "patternUserInfo",
-        patternNameNextJS: "patternNextJSUserInfo",
-        pathParamsInterfaceName: "PathParamsUserInfo",
-        pathParamsInterfaceNameNextJS: undefined,
-        urlParamsInterfaceName: "UrlParamsUserInfo",
-        filename: "patternUserInfo",
-        possiblePathParamsVariableName: "possilePathParamsUserInfo",
-      });
-    });
-
-    it("should generate template correctly for home page", () => {
-      const templateFile = plugin.generate({
-        routingType: "route-internal",
-        origin: "",
-        routePattern: "/",
-        destinationDir: "path/to/routes",
-        routeName: "UserInfo",
-        linkOptionModeNextJS: "strict",
-      });
-
-      expect(templateFile.type).toBe("pattern");
-      expect(templateFile.hasDefaultExport).toBe(false);
-      expect(templateFile.hasNamedExports).toBe(true);
-      expect(templateFile.routeName).toBe("UserInfo");
-      expect(templateFile.routingType).toBe("route-internal");
-      expect(templateFile.filename).toBe("patternUserInfo");
-      expect(templateFile.extension).toBe(".ts");
-      expect(templateFile.destinationDir).toBe("path/to/routes");
-      expect(templateFile.template).toMatchInlineSnapshot(`
-        "export const patternUserInfo = '/'
-            export const originUserInfo = ''
-            /** Recommended file paths:
-             * - \\"src/pages/index.tsx\\"
-             * - \\"pages/index.tsx\\"
-             */
-            export const patternNextJSUserInfo = \\"/\\"
-            
-            
-            
-            export interface UrlParamsUserInfo {
-              
-              query?: Record<string, string | undefined>;
-              origin?: string;
-            }"
-      `);
-      expect(templateFile.namedExports).toEqual({
-        originName: "originUserInfo",
-        patternName: "patternUserInfo",
-        patternNameNextJS: "patternNextJSUserInfo",
-        pathParamsInterfaceName: undefined,
-        pathParamsInterfaceNameNextJS: undefined,
-        urlParamsInterfaceName: "UrlParamsUserInfo",
-        filename: "patternUserInfo",
-        possiblePathParamsVariableName: undefined,
       });
     });
   });
@@ -222,7 +73,6 @@ describe("TypescriptPatternPlugin", () => {
         routePattern: "/app/users/:id/:subview(profile|pictures)",
         destinationDir: "path/to/routes",
         routeName: "UserInfo",
-        linkOptionModeNextJS: undefined,
       });
 
       expect(templateFile.type).toBe("pattern");
@@ -236,10 +86,7 @@ describe("TypescriptPatternPlugin", () => {
       expect(templateFile.template).toMatchInlineSnapshot(`
         "export const patternUserInfo = '/app/users/:id/:subview(profile|pictures)'
             export const originUserInfo = 'https://sample.domain.com'
-            
             export type PathParamsUserInfo = {id: string;subview:'profile'|'pictures';}
-            
-            export const possilePathParamsUserInfo = ['id','subview',]
             export interface UrlParamsUserInfo {
               path: PathParamsUserInfo;
               query?: Record<string, string | undefined>;
@@ -252,7 +99,6 @@ describe("TypescriptPatternPlugin", () => {
         pathParamsInterfaceName: "PathParamsUserInfo",
         urlParamsInterfaceName: "UrlParamsUserInfo",
         filename: "patternUserInfo",
-        possiblePathParamsVariableName: "possilePathParamsUserInfo",
       });
     });
   });

--- a/packages/core/src/plugins/typescript-pattern/TypescriptPatternPlugin.ts
+++ b/packages/core/src/plugins/typescript-pattern/TypescriptPatternPlugin.ts
@@ -1,27 +1,14 @@
 import { Key } from "path-to-regexp";
-import {
-  keyHelpers,
-  capitalizeFirstChar,
-  KeyType,
-  throwError,
-  BasePatternGenerator,
-  PatternTemplateFile,
-  PatternCodegenPlugin,
-} from "../../utils";
+import { keyHelpers, capitalizeFirstChar, KeyType, BasePatternGenerator, PatternTemplateFile, PatternCodegenPlugin } from "../../utils";
 
 interface PathParamsInterfaceResult {
   template: string;
   interfaceName: string;
 }
 
-interface PossibleParamsResult {
-  template: string;
-  variableName: string;
-}
-
 class TypescriptPatternGenerator extends BasePatternGenerator {
   generate(): PatternTemplateFile {
-    const { routePattern, routeName: originalRouteName, routingType, destinationDir, origin, linkOptionModeNextJS } = this.config;
+    const { routePattern, routeName: originalRouteName, routingType, destinationDir, origin } = this.config;
 
     const keys = keyHelpers.getKeysFromRoutePattern(routePattern);
 
@@ -31,19 +18,11 @@ class TypescriptPatternGenerator extends BasePatternGenerator {
     const originName = `origin${routeName}`;
     const filename = patternName;
     const pathParams = this._generatePathParamsInterface(keys, routeName);
-    const possiblePathParams = this._generatePossiblePathParams(keys, routeName);
     const urlParams = this._generateUrlParamsInterface(routeName, pathParams);
-
-    // TODO: handle next js pattern
-    const patternNextJS = linkOptionModeNextJS !== undefined ? this._generateNextJSPattern({ keys, routeName, routePattern }) : null;
-    const pathParamsNextJS = linkOptionModeNextJS === "loose" ? this._generateNextJSPathParams(keys, routeName) : null;
 
     const template = `export const ${patternName} = '${routePattern}'
     export const ${originName} = '${origin}'
-    ${patternNextJS ? patternNextJS.template : ""}
     ${pathParams ? pathParams.template : ""}
-    ${pathParamsNextJS ? pathParamsNextJS.template : ""}
-    ${possiblePathParams ? possiblePathParams.template : ""}
     ${urlParams.template}`;
 
     const result: PatternTemplateFile = {
@@ -52,10 +31,7 @@ class TypescriptPatternGenerator extends BasePatternGenerator {
       namedExports: {
         originName,
         patternName,
-        patternNameNextJS: patternNextJS ? patternNextJS.variableName : undefined,
         pathParamsInterfaceName: pathParams ? pathParams.interfaceName : undefined,
-        pathParamsInterfaceNameNextJS: pathParamsNextJS ? pathParamsNextJS.interfaceName : undefined,
-        possiblePathParamsVariableName: possiblePathParams ? possiblePathParams.variableName : undefined,
         urlParamsInterfaceName: urlParams.interfaceName,
         filename,
       },
@@ -108,22 +84,6 @@ class TypescriptPatternGenerator extends BasePatternGenerator {
     };
   }
 
-  _generatePossiblePathParams(keys: Key[], routeName: string): PossibleParamsResult | undefined {
-    if (keys.length === 0) {
-      return;
-    }
-
-    const variableName = `possilePathParams${routeName}`;
-    let template = `export const ${variableName} = [`;
-    template = keys.reduce((prevTemplate, { name }) => prevTemplate + `'${name}',`, template);
-    template += "]";
-
-    return {
-      template,
-      variableName,
-    };
-  }
-
   _generateUrlParamsInterface(
     routeName: string,
     pathParams: PathParamsInterfaceResult | undefined
@@ -137,78 +97,6 @@ class TypescriptPatternGenerator extends BasePatternGenerator {
     }`;
 
     return { template, interfaceName };
-  }
-
-  _generateNextJSPattern(params: { keys: Key[]; routePattern: string; routeName: string }): { template: string; variableName: string } {
-    const { keys, routeName, routePattern } = params;
-
-    const variableName = `patternNextJS${routeName}`;
-
-    const routeParts = routePattern.split("/");
-    // NextJS pattern uses [...] and no support for enums. Therefore, we need to turn:
-    // - ":id" to "[id]"
-    // - ":optional?" to "[optional]"
-    // - ":subview(profile|pictires)" to "[subview]"
-    // - ":optionalEnum(enumOne|enumTwo)?" to "[optionalEnum]"
-    const routePartsNextJS = routeParts.map((routePart) => {
-      if (routePart.charAt(0) !== ":") {
-        //not a dynamic path, just return
-        return routePart;
-      }
-
-      const matchedKey = keys.find((key) => {
-        switch (keyHelpers.getType(key)) {
-          case KeyType.normal: {
-            return routePart === `:${key.name}${keyHelpers.isOptional(key) ? "?" : ""}`;
-          }
-          case KeyType.enum: {
-            return routePart === `:${key.name}(${key.pattern})${keyHelpers.isOptional(key) ? "?" : ""}`;
-          }
-          default: {
-            return false;
-          }
-        }
-      });
-
-      // Cannot find a matchedKey for the routePart.. this shouldn't happen if we handle all the cases in ".find"
-      if (!matchedKey) {
-        return throwError([], `Cannot find key for ${routePart} in ${routePattern}`);
-      }
-
-      return `[${matchedKey.name}]`;
-    });
-
-    const routePath = `${routePartsNextJS.join("/")}`;
-    // We are already adding the last connecting "/" manually so we just remove the last "/" if the routePath ends with it
-    // An example is when the routePath is just "/"
-    const recommendedRoutePath = routePath.charAt(routePath.length - 1) === "/" ? routePath.slice(0, -1) : routePath;
-    const template = `/** Recommended file paths:
-     * - "src/pages${recommendedRoutePath}/index.tsx"
-     * - "pages${recommendedRoutePath}/index.tsx"
-     */
-    export const ${variableName} = "${routePath}"`;
-
-    return { template, variableName };
-  }
-
-  _generateNextJSPathParams(keys: Key[], routeName: string): PathParamsInterfaceResult | null {
-    if (keys.length === 0) {
-      return null;
-    }
-
-    const pathParamsInterfaceName = `PathParamsNextJS${routeName}`;
-    let template = `export interface ${pathParamsInterfaceName} {`;
-    keys.forEach((key) => {
-      // TODO: check if NextJS support optional param?
-      const fieldName = `${key.name}${keyHelpers.isOptional(key) ? "?" : ""}`;
-      template += `${fieldName}: string | string[];`;
-    });
-    template += "}";
-
-    return {
-      template,
-      interfaceName: pathParamsInterfaceName,
-    };
   }
 }
 

--- a/packages/core/src/plugins/typescript-react-router-5/TypescriptReactRouter5Plugin.test.ts
+++ b/packages/core/src/plugins/typescript-react-router-5/TypescriptReactRouter5Plugin.test.ts
@@ -32,7 +32,6 @@ describe("TypescriptReactRouter5Plugin - Link file", () => {
       filename: "patternLogin",
       patternName: "patternLogin",
       urlParamsInterfaceName: "UrlParamsLogin",
-      patternNameNextJS: "patternNextJSLogin",
     },
     importGenerateUrl: { namedImports: [{ name: "generateUrl" }], from: "route-codegen" },
     importRedirectServerSide: {
@@ -132,7 +131,6 @@ describe("TypescriptReactRouter5Plugin - Redirect file", () => {
       filename: "patternLogin",
       patternName: "patternLogin",
       urlParamsInterfaceName: "UrlParamsLogin",
-      patternNameNextJS: "patternNextJSLogin",
     },
     destinationDir: "path/to/routes",
     topLevelGenerateOptions: {

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -32,10 +32,7 @@ export interface NamedImport {
 export interface PatternNamedExports {
   originName: string;
   patternName: string;
-  patternNameNextJS?: string;
   pathParamsInterfaceName?: string;
-  pathParamsInterfaceNameNextJS?: string;
-  possiblePathParamsVariableName?: string;
   urlParamsInterfaceName: string;
   filename: string;
 }
@@ -59,7 +56,6 @@ export type PluginConfigType = "pattern" | "general" | "route-internal" | "route
 
 export interface CodegenPlugin<C, R> {
   type: PluginConfigType;
-  isNextJS?: boolean; // TODO: this is a hack and should be removed
   generate: (config: C) => R;
 }
 
@@ -80,8 +76,6 @@ export interface PatternPluginBaseConfig {
   routingType: RoutingType;
   routePattern: string;
   destinationDir: string;
-
-  linkOptionModeNextJS: "strict" | "loose" | undefined; // TODO: this is a hack and should be removed
 }
 export interface PatternCodegenPlugin<C = Record<string, unknown>>
   extends CodegenPlugin<WithExtraConfig<PatternPluginBaseConfig, C>, PatternTemplateFile> {

--- a/sample/outputs/default/app/routes/about/patternAbout.ts
+++ b/sample/outputs/default/app/routes/about/patternAbout.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/app/routes/contact/patternContact.ts
+++ b/sample/outputs/default/app/routes/contact/patternContact.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/app/routes/user/patternUser.ts
+++ b/sample/outputs/default/app/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/auth/routes/about/patternAbout.ts
+++ b/sample/outputs/default/auth/routes/about/patternAbout.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/auth/routes/contact/patternContact.ts
+++ b/sample/outputs/default/auth/routes/contact/patternContact.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/auth/routes/user/patternUser.ts
+++ b/sample/outputs/default/auth/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo-strict/routes/about/patternAbout.ts
+++ b/sample/outputs/default/seo-strict/routes/about/patternAbout.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo-strict/routes/contact/patternContact.ts
+++ b/sample/outputs/default/seo-strict/routes/contact/patternContact.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-/** Recommended file paths:
- * - "src/pages/contact/[target]/[topic]/[region]/[optional]/[optionalEnum]/index.tsx"
- * - "pages/contact/[target]/[topic]/[region]/[optional]/[optionalEnum]/index.tsx"
- */
-export const patternNextJSContact = "/contact/[target]/[topic]/[region]/[optional]/[optionalEnum]";
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -13,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo-strict/routes/contact/useParamsContact.ts
+++ b/sample/outputs/default/seo-strict/routes/contact/useParamsContact.ts
@@ -1,6 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { PathParamsContact } from "./patternContact";
 import { useRouter } from "next/router";
+import { PathParamsContact } from "./patternContact";
+
 export const useParamsContact = (): PathParamsContact => {
   const query = useRouter().query;
   return {

--- a/sample/outputs/default/seo-strict/routes/contact/useRedirectContact.ts
+++ b/sample/outputs/default/seo-strict/routes/contact/useRedirectContact.ts
@@ -1,22 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsContact, patternNextJSContact, possilePathParamsContact } from "./patternContact";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsContact, patternContact } from "./patternContact";
 export type RedirectFnContact = (urlParams: UrlParamsContact) => void;
 export const useRedirectContact = (): RedirectFnContact => {
   const router = useRouter();
   const redirect: RedirectFnContact = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = urlParams.path;
-    const pathname = possilePathParamsContact
-      .filter((key) => !(key in urlParams.path))
-      .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSContact);
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternContact, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/default/seo-strict/routes/user/patternUser.ts
+++ b/sample/outputs/default/seo-strict/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo/routes/about/patternAbout.ts
+++ b/sample/outputs/default/seo/routes/about/patternAbout.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-/** Recommended file paths:
- * - "src/pages/about/[target]/[topic]/[region]/[optional]/[optionalEnum]/index.tsx"
- * - "pages/about/[target]/[topic]/[region]/[optional]/[optionalEnum]/index.tsx"
- */
-export const patternNextJSAbout = "/about/[target]/[topic]/[region]/[optional]/[optionalEnum]";
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -13,14 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-export interface PathParamsNextJSAbout {
-  target: string | string[];
-  topic: string | string[];
-  region: string | string[];
-  optional?: string | string[];
-  optionalEnum?: string | string[];
-}
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo/routes/about/useParamsAbout.ts
+++ b/sample/outputs/default/seo/routes/about/useParamsAbout.ts
@@ -1,6 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import { PathParamsNextJSAbout } from "./patternAbout";
 import { useRouter } from "next/router";
+
+interface PathParamsNextJSAbout {
+  target: string | string[];
+  topic: string | string[];
+  region: string | string[];
+  optional?: string | string[];
+  optionalEnum?: string | string[];
+}
 export const useParamsAbout = (): PathParamsNextJSAbout => {
   const query = useRouter().query;
   return {

--- a/sample/outputs/default/seo/routes/about/useRedirectAbout.ts
+++ b/sample/outputs/default/seo/routes/about/useRedirectAbout.ts
@@ -1,22 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsAbout, patternNextJSAbout, possilePathParamsAbout } from "./patternAbout";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsAbout, patternAbout } from "./patternAbout";
 export type RedirectFnAbout = (urlParams: UrlParamsAbout) => void;
 export const useRedirectAbout = (): RedirectFnAbout => {
   const router = useRouter();
   const redirect: RedirectFnAbout = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = urlParams.path;
-    const pathname = possilePathParamsAbout
-      .filter((key) => !(key in urlParams.path))
-      .reduce((prevPattern, suppliedParam) => prevPattern.replace(`/[${suppliedParam}]`, ""), patternNextJSAbout);
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternAbout, { path: urlParams.path, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/default/seo/routes/contact/patternContact.ts
+++ b/sample/outputs/default/seo/routes/contact/patternContact.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo/routes/home/patternHome.ts
+++ b/sample/outputs/default/seo/routes/home/patternHome.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
 export const originHome = "";
-/** Recommended file paths:
- * - "src/pages/index.tsx"
- * - "pages/index.tsx"
- */
-export const patternNextJSHome = "/";
 
 export interface UrlParamsHome {
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/seo/routes/home/useRedirectHome.ts
+++ b/sample/outputs/default/seo/routes/home/useRedirectHome.ts
@@ -1,20 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsHome, patternNextJSHome } from "./patternHome";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsHome, patternHome } from "./patternHome";
 export type RedirectFnHome = (urlParams?: UrlParamsHome) => void;
 export const useRedirectHome = (): RedirectFnHome => {
   const router = useRouter();
   const redirect: RedirectFnHome = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = {};
-    const pathname = patternNextJSHome;
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/default/seo/routes/user/patternUser.ts
+++ b/sample/outputs/default/seo/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/server/routes/about/patternAbout.ts
+++ b/sample/outputs/default/server/routes/about/patternAbout.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/server/routes/contact/patternContact.ts
+++ b/sample/outputs/default/server/routes/contact/patternContact.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/server/routes/user/patternUser.ts
+++ b/sample/outputs/default/server/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/toc/routes/about/patternAbout.ts
+++ b/sample/outputs/default/toc/routes/about/patternAbout.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternAbout = "/about/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originAbout = "";
-
 export type PathParamsAbout = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsAbout = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsAbout = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsAbout {
   path: PathParamsAbout;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/toc/routes/contact/patternContact.ts
+++ b/sample/outputs/default/toc/routes/contact/patternContact.ts
@@ -1,7 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternContact = "/contact/:target(us|you)/:topic/:region(en)/:optional?/:optionalEnum(enumOne|enumTwo)?";
 export const originContact = "";
-
 export type PathParamsContact = {
   target: "us" | "you";
   topic: string;
@@ -9,8 +8,6 @@ export type PathParamsContact = {
   optional?: string;
   optionalEnum?: "enumOne" | "enumTwo";
 };
-
-export const possilePathParamsContact = ["target", "topic", "region", "optional", "optionalEnum"];
 export interface UrlParamsContact {
   path: PathParamsContact;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/toc/routes/toc/patternToc.ts
+++ b/sample/outputs/default/toc/routes/toc/patternToc.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternToc = "/terms-and-conditions";
 export const originToc = "";
-/** Recommended file paths:
- * - "src/pages/terms-and-conditions/index.tsx"
- * - "pages/terms-and-conditions/index.tsx"
- */
-export const patternNextJSToc = "/terms-and-conditions";
 
 export interface UrlParamsToc {
   query?: Record<string, string | undefined>;

--- a/sample/outputs/default/toc/routes/toc/useRedirectToc.ts
+++ b/sample/outputs/default/toc/routes/toc/useRedirectToc.ts
@@ -1,20 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsToc, patternNextJSToc } from "./patternToc";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsToc, patternToc } from "./patternToc";
 export type RedirectFnToc = (urlParams?: UrlParamsToc) => void;
 export const useRedirectToc = (): RedirectFnToc => {
   const router = useRouter();
   const redirect: RedirectFnToc = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = {};
-    const pathname = patternNextJSToc;
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternToc, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/default/toc/routes/user/patternUser.ts
+++ b/sample/outputs/default/toc/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/app/users/:id/:subview(pictures)?";
 export const originUser = "";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/app/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/outputs/with-origins/app/routes/activateAccount/patternActivateAccount.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
 export const originActivateAccount = "https://api.domain.com";
-
 export type PathParamsActivateAccount = { code: string };
-
-export const possilePathParamsActivateAccount = ["code"];
 export interface UrlParamsActivateAccount {
   path: PathParamsActivateAccount;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/app/routes/user/patternUser.ts
+++ b/sample/outputs/with-origins/app/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
 export const originUser = "https://app.domain.com";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/seo/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/outputs/with-origins/seo/routes/activateAccount/patternActivateAccount.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
 export const originActivateAccount = "https://api.domain.com";
-
 export type PathParamsActivateAccount = { code: string };
-
-export const possilePathParamsActivateAccount = ["code"];
 export interface UrlParamsActivateAccount {
   path: PathParamsActivateAccount;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/seo/routes/home/patternHome.ts
+++ b/sample/outputs/with-origins/seo/routes/home/patternHome.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternHome = "/";
 export const originHome = "https://domain.com";
-/** Recommended file paths:
- * - "src/pages/index.tsx"
- * - "pages/index.tsx"
- */
-export const patternNextJSHome = "/";
 
 export interface UrlParamsHome {
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/seo/routes/home/useRedirectHome.ts
+++ b/sample/outputs/with-origins/seo/routes/home/useRedirectHome.ts
@@ -1,20 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsHome, patternNextJSHome } from "./patternHome";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsHome, patternHome } from "./patternHome";
 export type RedirectFnHome = (urlParams?: UrlParamsHome) => void;
 export const useRedirectHome = (): RedirectFnHome => {
   const router = useRouter();
   const redirect: RedirectFnHome = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = {};
-    const pathname = patternNextJSHome;
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternHome, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/with-origins/seo/routes/terms/patternTerms.ts
+++ b/sample/outputs/with-origins/seo/routes/terms/patternTerms.ts
@@ -1,11 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternTerms = "/terms";
 export const originTerms = "https://domain.com";
-/** Recommended file paths:
- * - "src/pages/terms/index.tsx"
- * - "pages/terms/index.tsx"
- */
-export const patternNextJSTerms = "/terms";
 
 export interface UrlParamsTerms {
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/seo/routes/terms/useRedirectTerms.ts
+++ b/sample/outputs/with-origins/seo/routes/terms/useRedirectTerms.ts
@@ -1,20 +1,13 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 import { useRouter } from "next/router";
-import { UrlParamsTerms, patternNextJSTerms } from "./patternTerms";
+import { generateUrl } from "@route-codegen/utils";
+import { UrlParamsTerms, patternTerms } from "./patternTerms";
 export type RedirectFnTerms = (urlParams?: UrlParamsTerms) => void;
 export const useRedirectTerms = (): RedirectFnTerms => {
   const router = useRouter();
   const redirect: RedirectFnTerms = (urlParams) => {
-    const query = urlParams?.query ?? {};
-    const path = {};
-    const pathname = patternNextJSTerms;
-    router.push({
-      pathname: pathname,
-      query: {
-        ...path,
-        ...query,
-      },
-    });
+    const href = generateUrl(patternTerms, { path: {}, query: urlParams?.query, origin: urlParams?.origin });
+    router.push(href);
   };
   return redirect;
 };

--- a/sample/outputs/with-origins/seo/routes/user/patternUser.ts
+++ b/sample/outputs/with-origins/seo/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
 export const originUser = "https://app.domain.com";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/server/routes/activateAccount/patternActivateAccount.ts
+++ b/sample/outputs/with-origins/server/routes/activateAccount/patternActivateAccount.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternActivateAccount = "/activate-account/:code";
 export const originActivateAccount = "https://api.domain.com";
-
 export type PathParamsActivateAccount = { code: string };
-
-export const possilePathParamsActivateAccount = ["code"];
 export interface UrlParamsActivateAccount {
   path: PathParamsActivateAccount;
   query?: Record<string, string | undefined>;

--- a/sample/outputs/with-origins/server/routes/user/patternUser.ts
+++ b/sample/outputs/with-origins/server/routes/user/patternUser.ts
@@ -1,10 +1,7 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
 export const patternUser = "/users/:id/:subview(pictures)?";
 export const originUser = "https://app.domain.com";
-
 export type PathParamsUser = { id: string; subview?: "pictures" };
-
-export const possilePathParamsUser = ["id", "subview"];
 export interface UrlParamsUser {
   path: PathParamsUser;
   query?: Record<string, string | undefined>;

--- a/sample/package.json
+++ b/sample/package.json
@@ -9,7 +9,7 @@
     "postgenerate": "yarn format",
     "generate:default": "yarn route-codegen --stacktrace --verbose --config routegen.yml",
     "generate:with-origins": "PRIMARY_DOMAIN=domain.com yarn route-codegen --stacktrace --verbose --config routegen-with-origins.yml",
-    "format": "prettier --loglevel silent --config .prettierrc --write \"**/*.{ts,tsx}\"",
+    "format": "prettier --loglevel error --config .prettierrc --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR deprecates any NextJS patterns processing in the pattern plugin including path params.
NextJS does not need this pattern anymore as it can use the normal `generateUrl` to do routing now.
The only pattern that's still needed is the dynamic path params  interface which has been moved to NextJS plugin