### PR TITLE
Make route config component config optional

### DIFF
--- a/.changeset/soft-bulldogs-hunt.md
+++ b/.changeset/soft-bulldogs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@route-codegen/core": patch
+---
+
+Update TypescriptRouteConfigPlugin to handle cases without component config gracefully

--- a/packages/core/src/plugins/typescript-route-config/TypescriptRouteConfigPlugin.test.ts
+++ b/packages/core/src/plugins/typescript-route-config/TypescriptRouteConfigPlugin.test.ts
@@ -98,26 +98,60 @@ describe("TypescriptRouteConfig", () => {
     },
   };
 
-  it("throws error if internalComponent or externalComponent is not provided", () => {
-    expect(() => plugin.generate({ ...defaultConfig, extraConfig: undefined })).toThrow(
-      "internalComponent and externalComponent are required"
-    );
+  it("creates TemplateFile without component config", () => {
+    const result = plugin.generate({
+      ...defaultConfig,
+      files: [
+        internalPatternTemplateFile,
+        internalPatternTemplateFileWithPathParams,
+        externalPatternTemplateFile,
+        externalPatternTemplateFileWithPathParams,
+      ],
+      extraConfig: undefined,
+    });
 
-    expect(() =>
-      plugin.generate({
-        ...defaultConfig,
-        extraConfig: { internalComponent: defaultConfig.extraConfig?.internalComponent, externalComponent: undefined },
-      })
-    ).toThrow("internalComponent and externalComponent are required");
+    expect(result).toHaveLength(1);
 
-    expect(() =>
-      plugin.generate({
-        ...defaultConfig,
-        extraConfig: { externalComponent: defaultConfig.extraConfig?.externalComponent, internalComponent: undefined },
-      })
-    ).toThrow("internalComponent and externalComponent are required");
+    const [file] = result;
 
-    expect(() => plugin.generate({ ...defaultConfig })).not.toThrow("internalComponent and externalComponent are required");
+    expect(file.type).toBe(undefined);
+    expect(file.destinationDir).toBe("apps/");
+    expect(file.extension).toBe(".ts");
+    expect(file.filename).toBe("routeConfig");
+    expect(file.hasDefaultExport).toBe(false);
+    expect(file.hasNamedExports).toBe(true);
+    expect(file.routeName).toBe("");
+    expect(file.template).toMatchInlineSnapshot(`
+      "
+
+      import {urlParamsAbout,patternAbout,} from './about/patternAbout';import {urlParamsUser,patternUser,} from './user/patternUser';import {urlParamsTerms,patternTerms,} from './terms/patternTerms';import {urlParamsProject,patternProject,} from './terms/patternProject'
+      export const routeConfig: Record<string, { pathPattern:  string } 
+            & ( { type: \\"external\\"  } 
+              | { type: \\"internal\\"  })> = {
+      about: {
+                pathPattern: patternAbout,
+                type: \\"internal\\",
+                
+              },
+      user: {
+                pathPattern: patternUser,
+                type: \\"internal\\",
+                
+              },
+      terms: {
+                pathPattern: patternTerms,
+                type: \\"external\\",
+                
+              },
+      terms: {
+                pathPattern: patternProject,
+                type: \\"external\\",
+                
+              },
+      }
+      export type RouteConfigProps = 
+      { to: 'about', urlParams?: urlParamsAbout }|{ to: 'user', urlParams: urlParamsUser }|{ to: 'terms', urlParams?: urlParamsTerms }|{ to: 'terms', urlParams: urlParamsProject }"
+    `);
   });
 
   it("returns no file if no file supplied", () => {
@@ -172,27 +206,27 @@ describe("TypescriptRouteConfig", () => {
       import Link from '~/common/Link'
       import {urlParamsAbout,patternAbout,} from './about/patternAbout';import {urlParamsUser,patternUser,} from './user/patternUser';import {urlParamsTerms,patternTerms,} from './terms/patternTerms';import {urlParamsProject,patternProject,} from './terms/patternProject'
       export const routeConfig: Record<string, { pathPattern:  string } 
-            & ( { type: \\"external\\", component: typeof Link } 
-              | { type: \\"internal\\", component: \\"a\\" })> = {
+            & ( { type: \\"external\\" , component: typeof Link } 
+              | { type: \\"internal\\" , component: \\"a\\" })> = {
       about: {
                 pathPattern: patternAbout,
-                component: \\"a\\",
                 type: \\"internal\\",
+                component: \\"a\\",
               },
       user: {
                 pathPattern: patternUser,
-                component: \\"a\\",
                 type: \\"internal\\",
+                component: \\"a\\",
               },
       terms: {
                 pathPattern: patternTerms,
-                component: Link,
                 type: \\"external\\",
+                component: Link,
               },
       terms: {
                 pathPattern: patternProject,
-                component: Link,
                 type: \\"external\\",
+                component: Link,
               },
       }
       export type RouteConfigProps = 

--- a/sample/outputs/default/seo-strict/routes/routeConfig.ts
+++ b/sample/outputs/default/seo-strict/routes/routeConfig.ts
@@ -1,72 +1,59 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import Link from "~/common/components/Link";
-import { CustomAnchor } from "~/common/components/Anchor";
+
+import { UrlParamsContact, patternContact } from "./contact/patternContact";
 import { UrlParamsUser, patternUser } from "./user/patternUser";
 import { UrlParamsAccount, patternAccount } from "./account/patternAccount";
 import { UrlParamsLogin, patternLogin } from "./login/patternLogin";
 import { UrlParamsSignup, patternSignup } from "./signup/patternSignup";
 import { UrlParamsHome, patternHome } from "./home/patternHome";
 import { UrlParamsAbout, patternAbout } from "./about/patternAbout";
-import { UrlParamsContact, patternContact } from "./contact/patternContact";
 import { UrlParamsToc, patternToc } from "./toc/patternToc";
 import { UrlParamsLegacy, patternLegacy } from "./legacy/patternLegacy";
-export const routeConfig: Record<
-  string,
-  { pathPattern: string } & ({ type: "external"; component: typeof CustomAnchor } | { type: "internal"; component: typeof Link })
-> = {
+export const routeConfig: Record<string, { pathPattern: string } & ({ type: "external" } | { type: "internal" })> = {
+  contact: {
+    pathPattern: patternContact,
+    type: "internal",
+  },
   user: {
     pathPattern: patternUser,
-    type: "internal",
-    component: Link,
+    type: "external",
   },
   account: {
     pathPattern: patternAccount,
-    type: "internal",
-    component: Link,
+    type: "external",
   },
   login: {
     pathPattern: patternLogin,
     type: "external",
-    component: CustomAnchor,
   },
   signup: {
     pathPattern: patternSignup,
     type: "external",
-    component: CustomAnchor,
   },
   home: {
     pathPattern: patternHome,
     type: "external",
-    component: CustomAnchor,
   },
   about: {
     pathPattern: patternAbout,
     type: "external",
-    component: CustomAnchor,
-  },
-  contact: {
-    pathPattern: patternContact,
-    type: "external",
-    component: CustomAnchor,
   },
   toc: {
     pathPattern: patternToc,
     type: "external",
-    component: CustomAnchor,
   },
   legacy: {
     pathPattern: patternLegacy,
     type: "external",
-    component: CustomAnchor,
   },
 };
 export type RouteConfigProps =
+  | { to: "contact"; urlParams: UrlParamsContact }
   | { to: "user"; urlParams: UrlParamsUser }
   | { to: "account"; urlParams?: UrlParamsAccount }
   | { to: "login"; urlParams?: UrlParamsLogin }
   | { to: "signup"; urlParams?: UrlParamsSignup }
   | { to: "home"; urlParams?: UrlParamsHome }
   | { to: "about"; urlParams: UrlParamsAbout }
-  | { to: "contact"; urlParams: UrlParamsContact }
   | { to: "toc"; urlParams?: UrlParamsToc }
   | { to: "legacy"; urlParams?: UrlParamsLegacy };

--- a/sample/outputs/default/seo/routes/routeConfig.ts
+++ b/sample/outputs/default/seo/routes/routeConfig.ts
@@ -16,48 +16,48 @@ export const routeConfig: Record<
 > = {
   home: {
     pathPattern: patternHome,
-    component: Link,
     type: "internal",
+    component: Link,
   },
   about: {
     pathPattern: patternAbout,
-    component: Link,
     type: "internal",
+    component: Link,
   },
   user: {
     pathPattern: patternUser,
-    component: "a",
     type: "external",
+    component: "a",
   },
   account: {
     pathPattern: patternAccount,
-    component: "a",
     type: "external",
+    component: "a",
   },
   login: {
     pathPattern: patternLogin,
-    component: "a",
     type: "external",
+    component: "a",
   },
   signup: {
     pathPattern: patternSignup,
-    component: "a",
     type: "external",
+    component: "a",
   },
   contact: {
     pathPattern: patternContact,
-    component: "a",
     type: "external",
+    component: "a",
   },
   toc: {
     pathPattern: patternToc,
-    component: "a",
     type: "external",
+    component: "a",
   },
   legacy: {
     pathPattern: patternLegacy,
-    component: "a",
     type: "external",
+    component: "a",
   },
 };
 export type RouteConfigProps =

--- a/sample/outputs/default/toc/routes/routeConfig.ts
+++ b/sample/outputs/default/toc/routes/routeConfig.ts
@@ -1,6 +1,6 @@
 /* This file was automatically generated with route-codegen and should not be edited. */
-import Link from "~/common/components/Link";
-import { CustomAnchor } from "~/common/components/Anchor";
+
+import { UrlParamsToc, patternToc } from "./toc/patternToc";
 import { UrlParamsUser, patternUser } from "./user/patternUser";
 import { UrlParamsAccount, patternAccount } from "./account/patternAccount";
 import { UrlParamsLogin, patternLogin } from "./login/patternLogin";
@@ -8,59 +8,55 @@ import { UrlParamsSignup, patternSignup } from "./signup/patternSignup";
 import { UrlParamsHome, patternHome } from "./home/patternHome";
 import { UrlParamsAbout, patternAbout } from "./about/patternAbout";
 import { UrlParamsContact, patternContact } from "./contact/patternContact";
-import { UrlParamsToc, patternToc } from "./toc/patternToc";
 import { UrlParamsLegacy, patternLegacy } from "./legacy/patternLegacy";
-export const routeConfig: Record<
-  string,
-  { pathPattern: string } & ({ type: "external"; component: typeof CustomAnchor } | { type: "internal"; component: typeof Link })
-> = {
+export const routeConfig: Record<string, { pathPattern: string } & ({ type: "external"; component: "a" } | { type: "internal" })> = {
+  toc: {
+    pathPattern: patternToc,
+    type: "internal",
+  },
   user: {
     pathPattern: patternUser,
-    type: "internal",
-    component: Link,
+    type: "external",
+    component: "a",
   },
   account: {
     pathPattern: patternAccount,
-    type: "internal",
-    component: Link,
+    type: "external",
+    component: "a",
   },
   login: {
     pathPattern: patternLogin,
     type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
   signup: {
     pathPattern: patternSignup,
     type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
   home: {
     pathPattern: patternHome,
     type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
   about: {
     pathPattern: patternAbout,
     type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
   contact: {
     pathPattern: patternContact,
     type: "external",
-    component: CustomAnchor,
-  },
-  toc: {
-    pathPattern: patternToc,
-    type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
   legacy: {
     pathPattern: patternLegacy,
     type: "external",
-    component: CustomAnchor,
+    component: "a",
   },
 };
 export type RouteConfigProps =
+  | { to: "toc"; urlParams?: UrlParamsToc }
   | { to: "user"; urlParams: UrlParamsUser }
   | { to: "account"; urlParams?: UrlParamsAccount }
   | { to: "login"; urlParams?: UrlParamsLogin }
@@ -68,5 +64,4 @@ export type RouteConfigProps =
   | { to: "home"; urlParams?: UrlParamsHome }
   | { to: "about"; urlParams: UrlParamsAbout }
   | { to: "contact"; urlParams: UrlParamsContact }
-  | { to: "toc"; urlParams?: UrlParamsToc }
   | { to: "legacy"; urlParams?: UrlParamsLegacy };

--- a/sample/routegen.yml
+++ b/sample/routegen.yml
@@ -90,6 +90,7 @@ apps:
         config:
           mode: strict
       - name: "typescript-anchor"
+      - name: "typescript-route-config"
     generate:
       linkComponent: true
       useParams: true
@@ -118,6 +119,9 @@ apps:
             propsNamedImport: AnchorProps
             hrefProp: href
             from: ~/common/components/Anchor
+      - name: "typescript-route-config"
+        config:
+          externalComponent: "a"
     generate:
       linkComponent: true
       useParams: true


### PR DESCRIPTION
This makes `typescript-route-config` plugin much easier to use as it can just be a pure ts map and interface declaration 